### PR TITLE
Wire A4 onto the project Decoder + add Fig 9/10 extensions

### DIFF
--- a/src/analysis/stats/stability_flexibility_assignments_sandbox.ipynb
+++ b/src/analysis/stats/stability_flexibility_assignments_sandbox.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "271accd2",
+   "id": "d5de39fa",
    "metadata": {},
    "source": [
     "# Stability vs. Flexibility — Coding-Assignment Sandbox (A1–A6)\n",
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8235db03",
+   "id": "b8553c02",
    "metadata": {},
    "source": [
     "---\n",
@@ -54,10 +54,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e6611c9",
+   "id": "b374fb4d",
    "metadata": {},
    "outputs": [],
    "source": [
+    "%matplotlib inline\n",
     "# --- path setup so `src...` and `dcc_scripts...` import cleanly ---------------\n",
     "import os, sys, textwrap, warnings\n",
     "warnings.simplefilter(\"ignore\")\n",
@@ -107,7 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80564f5f",
+   "id": "166e590c",
    "metadata": {},
    "source": [
     "### The reveal registry\n",
@@ -118,7 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53e3beea",
+   "id": "e16b6ae1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -417,14 +418,27 @@
     "**A4 — hint 2 (mechanics).** Subjects don't share trials → build a *pseudopopulation*:\n",
     "features = electrodes, one **pseudo-trial** = for each electrode, the mean of `n_per_cell`\n",
     "sampled trials of a given class. Split raw trials into disjoint halves first (train pseudo-trials\n",
-    "from half A, test from half B). Classifier: any linear model — this sandbox uses\n",
-    "`make_pipeline(StandardScaler(), LogisticRegression())`; the **production drop-in wraps the\n",
-    "project `Decoder`** in `src/analysis/decoding/decoding.py`. Null = permute the *test* labels.\n",
+    "from half A, test from half B). Route fit/predict through one **backend helper** so you can\n",
+    "swap the compact `LogisticRegression` for the project `Decoder` (PCA+LDA) by flipping a flag —\n",
+    "`Decoder(categories={0:0,1:1}).fit(X, y).predict(X)` takes `(n_trials, n_features)`. Null =\n",
+    "permute the *test* labels.\n",
     "\"\"\")\n",
     "\n",
     "_register(\"a4_solution\", \"code\", \"\"\"\n",
-    "def _clf():\n",
-    "    return make_pipeline(StandardScaler(), LogisticRegression(max_iter=500))\n",
+    "def _fit_predict(Xtr, ytr, Xte, backend=None, explained_variance=0.8, random_state=0):\n",
+    "    \\\"\\\"\\\"Train on (Xtr,ytr) and predict Xte through a pluggable backend.\n",
+    "    backend: 'decoder' (project PCA+LDA Decoder), 'sklearn' (compact), None/'auto' -> A4_BACKEND.\\\"\\\"\\\"\n",
+    "    b = backend or globals().get(\"A4_BACKEND\", \"auto\")\n",
+    "    use_dec = (b == \"decoder\") or (b == \"auto\" and globals().get(\"_HAS_DECODER\", False))\n",
+    "    if use_dec:\n",
+    "        cats = {int(c): int(c) for c in np.unique(ytr)}          # binary {0,1}\n",
+    "        dec = Decoder(categories=cats, explained_variance=explained_variance,\n",
+    "                      n_splits=3, n_repeats=1, random_state=random_state)\n",
+    "        dec.fit(Xtr, ytr)\n",
+    "        return np.asarray(dec.predict(Xte))\n",
+    "    clf = make_pipeline(StandardScaler(), LogisticRegression(max_iter=500))\n",
+    "    clf.fit(Xtr, ytr)\n",
+    "    return clf.predict(Xte)\n",
     "\n",
     "def build_pseudo_trials(df, label_col, pos, neg, n_pseudo=60, n_per_cell=8, seed=0):\n",
     "    \\\"\\\"\\\"Pseudopopulation pseudo-trials: features=electrodes, one row = per-electrode\n",
@@ -466,7 +480,7 @@
     "        a.append(idx[:cut]); b.append(idx[cut:])\n",
     "    return df.loc[np.concatenate(a)], df.loc[np.concatenate(b)]\n",
     "\n",
-    "def cross_decode(df, train_spec, test_spec, strip_condition_means=False,\n",
+    "def cross_decode(df, train_spec, test_spec, strip_condition_means=False, backend=None,\n",
     "                 n_pseudo=80, n_per_cell=8, n_perm=200, seed=0):\n",
     "    \\\"\\\"\\\"Train on train_spec contrast, TEST on test_spec contrast (disjoint trials).\n",
     "    spec = (label_col, pos, neg), e.g. ('congruency','i','c'). Returns acc, null, p.\\\"\\\"\\\"\n",
@@ -478,12 +492,89 @@
     "    k = min(Xtr.shape[1], Xte.shape[1]); Xtr, Xte = Xtr[:, :k], Xte[:, :k]\n",
     "    if strip_condition_means:                                   # univariate-offset control\n",
     "        Xtr = remove_condition_means(Xtr, ytr); Xte = remove_condition_means(Xte, yte)\n",
-    "    acc = _clf().fit(Xtr, ytr).score(Xte, yte)\n",
+    "    acc = (_fit_predict(Xtr, ytr, Xte, backend) == yte).mean()\n",
     "    rng = np.random.default_rng(seed + 7)\n",
-    "    null = np.array([_clf().fit(Xtr, ytr).score(Xte, rng.permutation(yte))\n",
+    "    null = np.array([(_fit_predict(Xtr, ytr, Xte, backend) == rng.permutation(yte)).mean()\n",
     "                     for _ in range(n_perm)])\n",
     "    p = (np.sum(null >= acc) + 1) / (n_perm + 1)\n",
     "    return dict(accuracy=float(acc), null_mean=float(null.mean()), p=float(p))\n",
+    "\"\"\")\n",
+    "\n",
+    "# --- A4 within-block baseline (Fig 9) ---------------------------------------\n",
+    "_register(\"a4_within_hint\", \"md\", \"\"\"\n",
+    "**A4 within-block (Fig 9) — hint.** Decode the *same* contrast **within each block level**\n",
+    "and compare accuracies — the decoding analog of the univariate LWPC/LWPS effect. Congruency\n",
+    "should decode **better in mostly-incongruent blocks** (`incongruent_proportion` high), switch\n",
+    "better in mostly-switch blocks. It's just `cross_decode(sub, spec, spec)` on each block subset;\n",
+    "match trial counts first. The across-block *difference* is where the neural cross-effect lives.\n",
+    "\"\"\")\n",
+    "\n",
+    "_register(\"a4_within_solution\", \"code\", \"\"\"\n",
+    "def within_block_decoding_baseline(df, contrast_spec, block_col, backend=None,\n",
+    "                                   n_pseudo=60, n_per_cell=3, n_perm=100, seed=0):\n",
+    "    \\\"\\\"\\\"Decode contrast_spec WITHIN each level of block_col; compare accuracies (Fig 9).\\\"\\\"\\\"\n",
+    "    out = {}\n",
+    "    for b in sorted(df[block_col].dropna().unique()):\n",
+    "        sub = df[df[block_col] == b]\n",
+    "        out[b] = cross_decode(sub, contrast_spec, contrast_spec, backend=backend,\n",
+    "                              n_pseudo=n_pseudo, n_per_cell=n_per_cell, n_perm=n_perm, seed=seed)\n",
+    "    levels = sorted(out)\n",
+    "    diff = out[levels[-1]][\"accuracy\"] - out[levels[0]][\"accuracy\"]\n",
+    "    return dict(per_block=out, block_levels=levels, acc_difference=float(diff))\n",
+    "\"\"\")\n",
+    "\n",
+    "# --- A4 temporal generalization (Fig 10) ------------------------------------\n",
+    "_register(\"a4_tempgen_hint\", \"md\", \"\"\"\n",
+    "**A4 temporal generalization (Fig 10) — hint.** Train the decoder at time *t*, test at *t′*,\n",
+    "for all (t, t′) → a train×test accuracy matrix. Off-diagonal generalization = a sustained/stable\n",
+    "code; a narrow diagonal = a moving/phasic code. Needs **time-course** pseudo-trials — build an\n",
+    "`(n_pseudo, n_elec, n_bins)` tensor (per-electrode mean of sampled trials, keeping the time\n",
+    "axis), keep train/test disjoint, and loop the same `_fit_predict` over bin pairs (sub-sample\n",
+    "bins with a `stride` to keep it fast).\n",
+    "\"\"\")\n",
+    "\n",
+    "_register(\"a4_tempgen_solution\", \"code\", \"\"\"\n",
+    "def build_pseudo_trials_tc(df, label_col, pos, neg, n_pseudo=40, n_per_cell=8, seed=0, stride=2):\n",
+    "    \\\"\\\"\\\"Time-course pseudo-trials: X (n_pseudo, n_elec, n_binsub), y, kept bin indices.\\\"\\\"\\\"\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    electrodes = sorted(df[\"electrode\"].unique())\n",
+    "    T = len(np.asarray(df[\"hg\"].iloc[0])); bins = np.arange(0, T, stride)\n",
+    "    pools = {}\n",
+    "    for e in electrodes:\n",
+    "        for c in (pos, neg):\n",
+    "            sel = (df.electrode == e) & (df[label_col] == c)\n",
+    "            pools[(e, c)] = (np.vstack([np.asarray(v, float) for v in df[sel][\"hg\"].to_numpy()])\n",
+    "                             if sel.any() else None)\n",
+    "    X, y = [], []\n",
+    "    for c, lab in [(pos, 1), (neg, 0)]:\n",
+    "        for _ in range(n_pseudo):\n",
+    "            rows = []\n",
+    "            for e in electrodes:\n",
+    "                pool = pools[(e, c)]\n",
+    "                if pool is None:\n",
+    "                    rows.append(np.full(len(bins), np.nan)); continue\n",
+    "                idx = rng.choice(len(pool), size=min(n_per_cell, len(pool)), replace=False)\n",
+    "                rows.append(pool[idx][:, bins].mean(0))\n",
+    "            X.append(np.array(rows)); y.append(lab)\n",
+    "    X = np.array(X, float); y = np.array(y)\n",
+    "    good = ~np.isnan(X).any(axis=(0, 2))\n",
+    "    return X[:, good, :], y, bins\n",
+    "\n",
+    "def temporal_generalization(df, train_contrast, test_contrast=None, backend=None,\n",
+    "                            n_pseudo=40, n_per_cell=8, seed=0, stride=2):\n",
+    "    \\\"\\\"\\\"Train at time t, test at t' -> (n_bins x n_bins) accuracy matrix (Fig 10).\\\"\\\"\\\"\n",
+    "    test_contrast = test_contrast or train_contrast\n",
+    "    dfa, dfb = _disjoint_halves(df, seed)\n",
+    "    Xtr, ytr, bins = build_pseudo_trials_tc(dfa, *train_contrast, n_pseudo=n_pseudo,\n",
+    "                                            n_per_cell=n_per_cell, seed=seed, stride=stride)\n",
+    "    Xte, yte, _ = build_pseudo_trials_tc(dfb, *test_contrast, n_pseudo=n_pseudo,\n",
+    "                                         n_per_cell=n_per_cell, seed=seed + 1, stride=stride)\n",
+    "    k = min(Xtr.shape[1], Xte.shape[1]); Xtr, Xte = Xtr[:, :k, :], Xte[:, :k, :]\n",
+    "    nb = len(bins); M = np.zeros((nb, nb))\n",
+    "    for i in range(nb):\n",
+    "        for j in range(nb):\n",
+    "            M[i, j] = (_fit_predict(Xtr[:, :, i], ytr, Xte[:, :, j], backend) == yte).mean()\n",
+    "    return dict(matrix=M, bins=bins)\n",
     "\"\"\")\n",
     "\n",
     "# ------------------------------- A5 hints/solutions -------------------------\n",
@@ -624,7 +715,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3eb7928b",
+   "id": "b437d628",
    "metadata": {},
    "source": [
     "### Configuration — point this at your data\n",
@@ -643,7 +734,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db95946c",
+   "id": "1bd06f9c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -666,7 +757,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37aec7dc",
+   "id": "e46ce686",
    "metadata": {},
    "source": [
     "#### The loader: real LPFC data → synthetic fallback\n",
@@ -682,7 +773,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82648710",
+   "id": "88d66a2c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -745,7 +836,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a49076ca",
+   "id": "cff7aa33",
    "metadata": {},
    "source": [
     "#### Sanity-look at the data you'll be analyzing\n",
@@ -757,7 +848,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2de94b7",
+   "id": "6d78c405",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -774,7 +865,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47f93fb1",
+   "id": "76c590fd",
    "metadata": {},
    "source": [
     "---\n",
@@ -798,7 +889,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aaba6c4f",
+   "id": "4d805b7c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -814,7 +905,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "866ffad1",
+   "id": "ac991bb1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -834,7 +925,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1bd8d0d1",
+   "id": "445b370e",
    "metadata": {},
    "source": [
     "### Task A1.2 — `per_electrode_anova_labels` (all electrodes → S/F table)\n",
@@ -847,7 +938,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b58bd28",
+   "id": "59ffa5cb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -871,7 +962,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa751ab9",
+   "id": "a69d4578",
    "metadata": {},
    "source": [
     "#### Acceptance check A1\n",
@@ -886,7 +977,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85176825",
+   "id": "0d396ecb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -922,7 +1013,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d77f00b6",
+   "id": "af938725",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -947,7 +1038,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f0a393b",
+   "id": "6336e616",
    "metadata": {},
    "source": [
     "---\n",
@@ -970,7 +1061,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4894e44d",
+   "id": "f154ff10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -985,7 +1076,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62155ab5",
+   "id": "f643c2a5",
    "metadata": {},
    "source": [
     "#### Acceptance check A2.1\n",
@@ -999,7 +1090,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f55662e",
+   "id": "7f9a8907",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1028,7 +1119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cadaaae0",
+   "id": "0c012c3a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1045,7 +1136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ede7080",
+   "id": "64b22bfd",
    "metadata": {},
    "source": [
     "### Task A2.2 — `conjunction_threshold_sweep`\n",
@@ -1057,7 +1148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b589475b",
+   "id": "a389eef3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1071,7 +1162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08667eb1",
+   "id": "76042861",
    "metadata": {},
    "source": [
     "#### Acceptance check A2.2\n",
@@ -1084,7 +1175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db9378f1",
+   "id": "0cce6e1b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1111,7 +1202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ba088f4",
+   "id": "38689088",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1130,7 +1221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30ccc069",
+   "id": "4c8db592",
    "metadata": {},
    "source": [
     "---\n",
@@ -1154,7 +1245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c961c1ce",
+   "id": "f352ae9b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1202,7 +1293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4338dcc6",
+   "id": "e89384d5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1225,7 +1316,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0101e925",
+   "id": "f6a9f67e",
    "metadata": {},
    "source": [
     "#### Acceptance check A3\n",
@@ -1238,7 +1329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84e4ef89",
+   "id": "905ec8f0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1258,7 +1349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7fb790d8",
+   "id": "35b03293",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1276,7 +1367,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a996bed6",
+   "id": "853f0957",
    "metadata": {},
    "source": [
     "**Brain-surface plot (real-data only).** `plot_selectivity_groups_on_brain` is a thin\n",
@@ -1289,7 +1380,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a402af21",
+   "id": "3af10d32",
    "metadata": {},
    "source": [
     "---\n",
@@ -1301,11 +1392,13 @@
     "and **per-condition mean removal** (a cross-effect that vanishes after mean removal was a\n",
     "univariate offset, not a code).\n",
     "\n",
-    "> **Scope note.** The production drop-in (`src/analysis/decoding/cross_decoding.py`) wraps the\n",
-    "> project's `Decoder`; this sandbox uses a compact `LogisticRegression` so it's fully runnable.\n",
-    "> We implement the core — pseudo-trials, mean removal, label-transfer `cross_decode` with a\n",
-    "> null. *Set-transfer, within-block baseline (Fig 9), and temporal generalization (Fig 10)*\n",
-    "> are guided extensions (see the assignment doc / `docs/skeletons/a4_cross_decoding.py`).\n",
+    "> **Backend.** `cross_decode` runs through a **pluggable classifier backend**: the project's\n",
+    "> real `Decoder` (PCA + LDA, from `src/analysis/decoding/decoding.py`) when it's importable, or\n",
+    "> a compact `LogisticRegression` fallback so the sandbox runs even without the `ieeg`/`mne`\n",
+    "> stack. Same pseudo-trial + disjoint-split + null discipline either way — the production\n",
+    "> drop-in (`src/analysis/decoding/cross_decoding.py`) simply pins `backend='decoder'`.\n",
+    "> This section covers the label-transfer core **plus** the within-block baseline (Fig 9) and\n",
+    "> temporal generalization (Fig 10); set-transfer (design b) remains a short exercise.\n",
     "\n",
     "*Hints:* `reveal(\"a4_hint1\")`, `reveal(\"a4_hint2\")`. *Answer:* `reveal(\"a4_solution\")` / `load_reference(\"a4\")`."
    ]
@@ -1313,10 +1406,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "604c8d58",
+   "id": "1630ddb0",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# --- pick the classifier backend: real project Decoder if available, else compact ---\n",
+    "try:\n",
+    "    from src.analysis.decoding.decoding import Decoder\n",
+    "    _HAS_DECODER = True\n",
+    "except Exception as e:\n",
+    "    _HAS_DECODER = False\n",
+    "    print(f\"project Decoder unavailable ({type(e).__name__}: {e}) — compact classifier only\")\n",
+    "\n",
+    "# importing ieeg/mne hijacks the matplotlib backend (→ Agg), which kills inline\n",
+    "# figures for the plots below. Restore inline rendering.\n",
+    "try:\n",
+    "    get_ipython().run_line_magic(\"matplotlib\", \"inline\")\n",
+    "except Exception:\n",
+    "    pass\n",
+    "\n",
+    "# 'auto' -> Decoder if importable else sklearn; force with 'decoder' / 'sklearn'\n",
+    "A4_BACKEND = \"auto\"\n",
+    "_resolved = (\"decoder\" if (A4_BACKEND == \"decoder\" or (A4_BACKEND == \"auto\" and _HAS_DECODER))\n",
+    "             else \"sklearn\")\n",
+    "print(f\"Decoder importable: {_HAS_DECODER} | A4_BACKEND={A4_BACKEND!r} -> using {_resolved!r}\")\n",
+    "\n",
     "# For speed on the synthetic fallback (hundreds of electrodes), sub-sample the\n",
     "# pseudopopulation; real LPFC data (few electrodes) is used whole.\n",
     "_elecs = sorted(df[\"electrode\"].unique())\n",
@@ -1332,31 +1446,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4a715a4",
+   "id": "3e59dba0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Task A4.1-3\n",
+    "# Task A4.1-4\n",
+    "def _fit_predict(Xtr, ytr, Xte, backend=None, explained_variance=0.8, random_state=0):\n",
+    "    \"\"\"Train on (Xtr,ytr), predict Xte, via a pluggable backend. 'decoder' -> project\n",
+    "    Decoder (PCA+LDA); 'sklearn' -> compact pipeline; None/'auto' -> the A4_BACKEND global.\"\"\"\n",
+    "    raise NotImplementedError(\"A4.1 — backend fit/predict (wraps Decoder or LogisticRegression)\")\n",
+    "\n",
     "def build_pseudo_trials(df, label_col, pos, neg, n_pseudo=60, n_per_cell=8, seed=0):\n",
     "    \"\"\"Pseudopopulation pseudo-trials (features=electrodes; one row = per-electrode mean of\n",
     "    n_per_cell sampled trials of a class). Return (X, y).\"\"\"\n",
-    "    raise NotImplementedError(\"A4.1 — pseudo-trial construction\")\n",
+    "    raise NotImplementedError(\"A4.2 — pseudo-trial construction\")\n",
     "\n",
     "def remove_condition_means(X, condition_labels):\n",
     "    \"\"\"Subtract each condition's per-feature mean (the univariate-offset control).\"\"\"\n",
-    "    raise NotImplementedError(\"A4.2 — per-condition mean removal\")\n",
+    "    raise NotImplementedError(\"A4.3 — per-condition mean removal\")\n",
     "\n",
-    "def cross_decode(df, train_spec, test_spec, strip_condition_means=False,\n",
+    "def cross_decode(df, train_spec, test_spec, strip_condition_means=False, backend=None,\n",
     "                 n_pseudo=80, n_per_cell=8, n_perm=200, seed=0):\n",
     "    \"\"\"Train on train_spec contrast, TEST on test_spec (disjoint trials). spec =\n",
     "    (label_col, pos, neg). Return dict(accuracy, null_mean, p). See reveal for the disjoint-\n",
-    "    half helper `_disjoint_halves` + `_clf`.\"\"\"\n",
-    "    raise NotImplementedError(\"A4.3 — cross-condition label transfer\")"
+    "    half helper `_disjoint_halves` (uses `_fit_predict` for the backend).\"\"\"\n",
+    "    raise NotImplementedError(\"A4.4 — cross-condition label transfer\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2fa56d2e",
+   "id": "d9ee8dc5",
    "metadata": {},
    "source": [
     "#### Acceptance check A4 (the §0.8 confound controls)\n",
@@ -1371,7 +1490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "062b9571",
+   "id": "eaa76351",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1400,7 +1519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26729d7f",
+   "id": "8e185e8f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1420,7 +1539,145 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5fda135e",
+   "id": "5d5d58ff",
+   "metadata": {},
+   "source": [
+    "### A4 · Within-block decoding baseline (Fig 9)\n",
+    "Decode a contrast **within each block level** and compare accuracies — the decoding analog of\n",
+    "the univariate LWPC/LWPS effect, and where the neural cross-effect surfaces: congruency should\n",
+    "decode **better in mostly-incongruent blocks**.\n",
+    "*Hint:* `reveal(\"a4_within_hint\")`. *Answer:* `reveal(\"a4_within_solution\")` / `load_reference(\"a4_within\")`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d96395f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Task A4.5\n",
+    "def within_block_decoding_baseline(df, contrast_spec, block_col, backend=None,\n",
+    "                                   n_pseudo=60, n_per_cell=3, n_perm=100, seed=0):\n",
+    "    \"\"\"Decode contrast_spec WITHIN each level of block_col; compare accuracies (Fig 9).\n",
+    "    Return dict(per_block={level: cross_decode result}, block_levels, acc_difference).\"\"\"\n",
+    "    raise NotImplementedError(\"A4.5 — within-block decoding baseline (Fig 9)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8392523",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if _HAS_SKLEARN:\n",
+    "    # few electrodes so decoding isn't at ceiling and the block modulation is visible\n",
+    "    _wb_el = sorted(df[\"electrode\"].unique())\n",
+    "    if len(_wb_el) > 12:\n",
+    "        _wk = set(np.random.default_rng(1).choice(_wb_el, 10, replace=False))\n",
+    "        df_wb = df[df[\"electrode\"].isin(_wk)].copy()\n",
+    "    else:\n",
+    "        df_wb = df\n",
+    "    # compact backend here: PCA+LDA pools the few electrodes to ceiling in BOTH blocks,\n",
+    "    # which hides the modulation; the compact classifier keeps accuracy off-ceiling so the\n",
+    "    # LWPC ordering is visible. On real LPFC data (more electrodes) either backend works.\n",
+    "    wb = within_block_decoding_baseline(df_wb, (\"congruency\", \"i\", \"c\"),\n",
+    "                                        \"incongruent_proportion\", backend=\"sklearn\",\n",
+    "                                        n_pseudo=50, n_per_cell=2, n_perm=60)\n",
+    "    for b, r in wb[\"per_block\"].items():\n",
+    "        print(f\"  incongruent_proportion={b:g}: congruency decode acc={r['accuracy']:.2f} (p={r['p']:.3f})\")\n",
+    "    print(f\"→ Δacc(high − low block) = {wb['acc_difference']:+.2f}  \"\n",
+    "          f\"(neural LWPC: congruency decodes better in mostly-incongruent blocks)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3c3d57f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if _HAS_SKLEARN:\n",
+    "    fig, ax = plt.subplots(figsize=(5.5, 4))\n",
+    "    lv = wb[\"block_levels\"]; accs = [wb[\"per_block\"][b][\"accuracy\"] for b in lv]\n",
+    "    ax.bar([f\"{b:g}%\\nincong.\" for b in lv], accs, color=[\"#9ecae1\", \"#2c7fb8\"])\n",
+    "    ax.axhline(0.5, ls=\"--\", c=\"k\", lw=1, label=\"chance\")\n",
+    "    for i, v in enumerate(accs): ax.text(i, v, f\"{v:.2f}\", ha=\"center\", va=\"bottom\")\n",
+    "    ax.set(title=\"Within-block congruency decoding (Fig 9)\\n\"\n",
+    "                 \"higher in mostly-incongruent blocks = neural LWPC\",\n",
+    "           ylabel=\"accuracy\", ylim=(0, 1.05)); ax.legend()\n",
+    "    fig.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10dddba6",
+   "metadata": {},
+   "source": [
+    "### A4 · Temporal generalization (Fig 10)\n",
+    "Train at time *t*, test at *t′*, for all pairs → a train×test accuracy matrix. A broad\n",
+    "off-diagonal block = a **sustained/stable** code; a narrow diagonal = a **moving/phasic** code.\n",
+    "Needs time-course pseudo-trials. *(Demo uses a compact cluster-mode synthetic; for real LPFC\n",
+    "time courses pass the `effect_measure='cluster'` df from A5's `load_timing_df(CONFIG)`.)*\n",
+    "*Hint:* `reveal(\"a4_tempgen_hint\")`. *Answer:* `reveal(\"a4_tempgen_solution\")` / `load_reference(\"a4_tempgen\")`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69fcdd41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Task A4.6\n",
+    "def build_pseudo_trials_tc(df, label_col, pos, neg, n_pseudo=40, n_per_cell=8, seed=0, stride=2):\n",
+    "    \"\"\"Time-course pseudo-trials: X (n_pseudo, n_elec, n_binsub), y, kept bin indices.\"\"\"\n",
+    "    raise NotImplementedError(\"A4.6a — time-course pseudo-trials\")\n",
+    "\n",
+    "def temporal_generalization(df, train_contrast, test_contrast=None, backend=None,\n",
+    "                            n_pseudo=40, n_per_cell=8, seed=0, stride=2):\n",
+    "    \"\"\"Train at time t, test at t' -> (n_bins x n_bins) accuracy matrix (Fig 10).\"\"\"\n",
+    "    raise NotImplementedError(\"A4.6b — temporal generalization matrix\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2d0f5b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if _HAS_SKLEARN:\n",
+    "    from src.analysis.stats.stability_flexibility_segregation import _synthetic_df as _sd\n",
+    "    _tc = _sd(effect_measure=\"cluster\", n_time=16, seed=0)\n",
+    "    _kc = set(np.random.default_rng(1).choice(sorted(_tc.electrode.unique()), 60, replace=False))\n",
+    "    _tc = _tc[_tc.electrode.isin(_kc)].copy()\n",
+    "    tg = temporal_generalization(_tc, (\"congruency\", \"i\", \"c\"), n_pseudo=30, stride=2)\n",
+    "    M = tg[\"matrix\"]\n",
+    "    print(f\"train×test matrix {M.shape}: diagonal mean={np.mean(np.diag(M)):.2f}, \"\n",
+    "          f\"off-diagonal mean={np.mean(M[~np.eye(len(M), dtype=bool)]):.2f}\")\n",
+    "    print(\"(effect is injected in the middle-half window → a sustained block there)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82fc0305",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if _HAS_SKLEARN:\n",
+    "    fig, ax = plt.subplots(figsize=(5.4, 4.6))\n",
+    "    im = ax.imshow(M, origin=\"lower\", cmap=\"magma\", vmin=0.4, vmax=1.0, aspect=\"equal\")\n",
+    "    ax.set(title=\"Temporal generalization (Fig 10)\\ncongruency code: train t × test t'\",\n",
+    "           xlabel=\"test time bin\", ylabel=\"train time bin\")\n",
+    "    plt.colorbar(im, ax=ax, label=\"accuracy\"); fig.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ce9c4c9",
    "metadata": {},
    "source": [
     "---\n",
@@ -1444,7 +1701,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7e030113",
+   "id": "1e5ca37b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1512,7 +1769,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec531546",
+   "id": "036ba320",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1537,7 +1794,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f556368e",
+   "id": "6e1cc606",
    "metadata": {},
    "source": [
     "#### Acceptance check A5\n",
@@ -1550,7 +1807,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58018dac",
+   "id": "146b7f0d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1576,7 +1833,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38352a26",
+   "id": "5b3d8c80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1594,7 +1851,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffeeda9e",
+   "id": "7268e869",
    "metadata": {},
    "source": [
     "---\n",
@@ -1616,7 +1873,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01532586",
+   "id": "c18841fe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1646,7 +1903,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e22d6ec",
+   "id": "71bd1222",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1665,7 +1922,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0fb34c50",
+   "id": "c4cb48d5",
    "metadata": {},
    "source": [
     "#### Acceptance check A6\n",
@@ -1678,7 +1935,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46355071",
+   "id": "4f0caa9f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1699,7 +1956,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4c37f42",
+   "id": "843f555b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1718,7 +1975,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a7698d8",
+   "id": "678c2855",
    "metadata": {},
    "source": [
     "---\n",
@@ -1730,8 +1987,9 @@
     "   `per_electrode_labels` / `cmh_conjunction`).\n",
     "2. **A3** → new `stability_flexibility_anatomy.py` (stats) + the `vis/` Glasser renderer for\n",
     "   the brain plot. **A5** → new `stability_flexibility_timing.py`. **A6** → new\n",
-    "   `stability_flexibility_brain_behavior.py`. **A4** → new `decoding/cross_decoding.py` that\n",
-    "   wraps the project `Decoder` (this sandbox used a compact classifier).\n",
+    "   `stability_flexibility_brain_behavior.py`. **A4** → new `decoding/cross_decoding.py`: the\n",
+    "   `_fit_predict` backend already wraps the project `Decoder` — pin `backend='decoder'` there\n",
+    "   and drop the `LogisticRegression` fallback.\n",
     "3. Delete the corresponding `docs/skeletons/aN_*.py` stubs, and lift the acceptance checks\n",
     "   here into `tests/`.\n",
     "\n",
@@ -1744,10 +2002,13 @@
     "- **Decoding confounds** — A4 per-condition mean removal + label-permutation null.\n",
     "- **Latency–amplitude** — A5 50%-of-peak onset + peak latency + the k-scaling unit test.\n",
     "\n",
-    "### A4 extensions left as exercises (see `docs/skeletons/a4_cross_decoding.py`)\n",
-    "Set-transfer (design b), within-block decoding baseline (Fig 9), and temporal generalization\n",
-    "(Fig 10) reuse the same pseudo-trial + disjoint-split discipline — natural next steps once the\n",
-    "label-transfer core here is solid."
+    "### A4 · what's here vs. one remaining exercise\n",
+    "Implemented and runnable: pseudo-trials, per-condition mean removal, label-transfer\n",
+    "`cross_decode` (with the pluggable Decoder/​sklearn backend), the within-block baseline\n",
+    "(Fig 9), and temporal generalization (Fig 10). **Set-transfer (design b)** — train on one\n",
+    "electrode set, test on the other for the *same* label — reuses the exact same machinery\n",
+    "(swap the electrode subset instead of the contrast) and is left as a short exercise; see\n",
+    "`docs/skeletons/a4_cross_decoding.py`."
    ]
   }
  ],


### PR DESCRIPTION
- Pluggable classifier backend: cross_decode (and the new decoders) route fit/predict through _fit_predict, which uses the project's real Decoder (PCA+LDA, src/analysis/decoding/decoding.py) when importable and a compact LogisticRegression otherwise. A4_BACKEND selects auto/decoder/sklearn; the production drop-in just pins backend='decoder'.
- within_block_decoding_baseline (Fig 9): decode a contrast within each block level and compare accuracies (neural LWPC/LWPS); demonstrates congruency decoding higher in mostly-incongruent blocks.
- build_pseudo_trials_tc + temporal_generalization (Fig 10): train-t x test-t' accuracy matrix on time-course pseudo-trials, showing a sustained code block.
- Restore the inline matplotlib backend after importing Decoder (ieeg/mne forces Agg, which had suppressed the A4/A5/A6 inline figures); add %matplotlib inline to setup.

Set-transfer (design b) remains a short exercise. Validated end-to-end with both backends (all 63 cells execute; 9 figures render).


Claude-Session: https://claude.ai/code/session_01ThHcV79to7iAxKbHQVdDxp