### PR TITLE
Add DCC launchers for A5 (timing) and A6 (brain-behavior)

### DIFF
--- a/dcc_scripts/stats/README.md
+++ b/dcc_scripts/stats/README.md
@@ -173,3 +173,203 @@ Written to `results/<epochs_or_synthetic_tag>/anatomy_window_<tmin>to<tmax>s_<el
 **Reading:** a significant test means selectivity-group membership is associated
 with ROI *beyond* what electrode placement forces; per-ROI coverage is reported so
 no claim rests on where the grid happens to be.
+
+---
+
+# A5 — Timing: relative onset of stability vs. flexibility
+
+Does the **LWPC** (stability) interaction arise *earlier* in the trial than the
+**LWPS** (flexibility) interaction, or later? A *sequence* question neither the
+conjunction (A2) nor the cross-decoding (A4) layer speaks to. Analysis code lives
+in `src/analysis/stats/stability_flexibility_timing.py`; a step-by-step
+walk-through is in `stability_flexibility_a5_a6_tutorial.ipynb` (next to that
+module).
+
+## Files
+
+| File | Role |
+|---|---|
+| `stability_flexibility_timing_dcc.py` | Core: assembles the long df in **time-course** mode, builds the per-bin interaction traces, measures onsets/peaks, runs the jackknife, writes figures + `summary.txt`. Exposes `main(args)`. |
+| `run_stability_flexibility_timing_dcc.py` | Entrypoint: sets parameters (env-overridable) and calls `main`. |
+| `sbatch_stability_flexibility_timing_dcc.sh` | SLURM wrapper (`conda activate ieeg` → entrypoint). |
+| `submit_stability_flexibility_timing_dcc.sh` | Sets `EPOCHS_ROOT_FILE`/window/etc. and `sbatch`-submits. |
+
+## Quick start
+
+```bash
+cd dcc_scripts/stats
+# validate the whole path in seconds against a PLANTED onset ordering
+# (stability at 0.20 s, flexibility at 0.40 s — the job should recover both):
+DATA_SOURCE=synthetic bash submit_stability_flexibility_timing_dcc.sh
+# the falsification: plant the REVERSE ordering; the reported sign must flip:
+DATA_SOURCE=synthetic SYNTHETIC_STAB_ONSET=0.40 SYNTHETIC_FLEX_ONSET=0.20 \
+    bash submit_stability_flexibility_timing_dcc.sh
+# real run — set EPOCHS_ROOT_FILE in the submit script, then:
+bash submit_stability_flexibility_timing_dcc.sh
+```
+
+## What it does
+
+0. Runs `_assert_amplitude_invariance` **first** — the latency–amplitude guard as a
+   live assertion (scaling a waveform by `k` must not move its 50 %-of-peak onset).
+   A failure there would invalidate every onset the job goes on to report.
+1. Assembles the long table with `effect_measure='cluster'`, so `hg` holds each
+   trial's **time course** over the window, plus the window time axis
+   (`window_times`, which also verifies every subject shares one axis — bin-by-bin
+   grand-averaging is meaningless otherwise).
+2. `interaction_time_course` per process: the **equal-cell-weight
+   difference-of-differences** of the four `(cond, mod)` cell means per time bin,
+   combined across electrodes. Equal cell weighting keeps the estimate orthogonal
+   to both main effects, so the ~75/25 proportion imbalance can't leak a main
+   effect in as a fake interaction.
+3. `onset_50pct_peak` (onset) and `peak_latency` (shape cross-check) on each trace.
+   Normalizing to each effect's **own** peak is what defeats the latency–amplitude
+   confound: a bigger effect crosses any *absolute* threshold sooner, so without it
+   "earlier" would just rename "larger".
+4. `jackknife_onset_difference`: onsets read off **smooth leave-one-subject-out
+   grand averages**, jackknife SE, and the Ulrich–Miller `(N−1)`-corrected paired
+   *t* on the LWPC − LWPS difference.
+
+## Key knobs (env vars)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `DATA_SOURCE` | `real` | `real` = epoched HG time courses; `synthetic` = planted-onset dry run. |
+| `SYNTHETIC_STAB_ONSET` / `SYNTHETIC_FLEX_ONSET` | `0.20` / `0.40` | synthetic only: the planted onsets (s). Swap them for the falsification run. |
+| `SYNTHETIC_N_SUBJ` | `12` | synthetic only: number of subjects. |
+| `WINDOW_TMIN` / `WINDOW_TMAX` | `-0.2` / `0.8` | analysis window (s from stimulus onset) — **wider than the A1/A2 default on purpose**: A5 reads a rising flank, so the window must include the baseline and enough post-stimulus time for both effects to turn over. |
+| `ELECTRODES` | `all` | `all` or `sig`. |
+| `STATISTIC` | `mean` | `mean` = grand-average the per-electrode d-o-d(t); `t` = t across electrodes (noise-normalized, often a cleaner flank). |
+| `ALPHA` | `0.05` | significance threshold for the reported verdict. |
+
+## Outputs
+
+Written to `results/<epochs_or_synthetic_tag>/timing_window_<tmin>to<tmax>s_<electrodes>_<statistic>/`:
+
+- `interaction_time_courses.csv` — `time`, `lwpc`, `lwps`: the per-bin
+  difference-of-differences behind every onset (the reusable artifact; the
+  time-course long table itself is far too large to serialize).
+- `jackknife_leave_one_out.csv` — the `N` leave-one-out onset pairs and differences.
+- `onset_difference.json` — full-sample onsets/peaks, the jackknife SE, `t_raw`,
+  `t_corrected`, `p`, and the 95 % CI.
+- `timing_summary.png` — 3 panels: the two traces with onset/peak markers, the
+  leave-one-out onsets, and the distribution of leave-one-out differences.
+- `summary.txt` — printed verdict.
+
+**Reading:** the **sign** of the onset difference says which process's information
+arises first (negative = stability leads); the CI / `(N−1)`-corrected *t* say
+whether that ordering is reliable. Claim an ordering only when **onset and peak
+latency agree** — `summary.txt` checks that for you, and warns instead when an
+effect is still at its ceiling at `WINDOW_TMAX` (its "peak" is then just the last
+bin and carries no latency information — widen the window).
+
+---
+
+# A6 — Brain–behavior correlation
+
+Does the A1 neural selectivity predict the **actual behavioral control
+adjustment**? Analysis code lives in
+`src/analysis/stats/stability_flexibility_brain_behavior.py`; a step-by-step
+walk-through is in `stability_flexibility_a5_a6_tutorial.ipynb`.
+
+## Files
+
+| File | Role |
+|---|---|
+| `stability_flexibility_brain_behavior_dcc.py` | Core: runs A1 for the S/F flags, derives the per-subject behavioral LWPC/LWPS RT magnitudes, runs both correlation levels with their cross-pairing controls, writes figures + `summary.txt`. Exposes `main(args)`. |
+| `run_stability_flexibility_brain_behavior_dcc.py` | Entrypoint: sets parameters (env-overridable) and calls `main`. |
+| `sbatch_stability_flexibility_brain_behavior_dcc.sh` | SLURM wrapper (`conda activate ieeg` → entrypoint). |
+| `submit_stability_flexibility_brain_behavior_dcc.sh` | Sets `EPOCHS_ROOT_FILE`/`BEHAVIOR_CSV`/window/etc. and `sbatch`-submits. |
+
+## Quick start
+
+```bash
+cd dcc_scripts/stats
+# validate the whole path in seconds — a planted matched coupling that beats its
+# cross control at BOTH levels:
+DATA_SOURCE=synthetic bash submit_stability_flexibility_brain_behavior_dcc.sh
+# the falsification: make each neural group drive BOTH adjustments equally;
+# `specificity_ok` must stop holding:
+DATA_SOURCE=synthetic SYNTHETIC_CROSS_FRAC=1.0 \
+    bash submit_stability_flexibility_brain_behavior_dcc.sh
+# real run — set EPOCHS_ROOT_FILE (and BEHAVIOR_CSV if not the repo-root copy):
+bash submit_stability_flexibility_brain_behavior_dcc.sh
+```
+
+## What it does
+
+1. Assembles the same window-mean long table as the A1/A2/A3 jobs and runs the A1
+   electrode definition (`per_electrode_anova_labels`, `contrast_mode='proportion'`)
+   → per-electrode `S`/`F` flags.
+2. **Behavior**: per-subject LWPC/LWPS RT magnitudes from the raw trial table
+   (`combinedData.csv`; `subject_ID` is renamed to `subject` on load) via
+   `behavioral_lwpc_lwps_magnitudes` — the **same** equal-cell-weight
+   difference-of-differences used for the neural interaction, so brain and behavior
+   are measured on the identical contrast.
+3. **(1) Across subjects** (`subject_level_brain_behavior`) for all three neural
+   summaries — `count` (`n_S`/`n_F`), `frac`, and `effect` (mean interaction F) —
+   each with its **cross-pairing** control. Underpowered at *n* = subjects by
+   design; reported with that caveat attached.
+4. **(2) Within subject, single trial** (`trialwise_brain_behavior`) — the powered
+   test. `assemble_trial_table` builds a per-(subject, trial) table with RT and the
+   window-mean HG averaged over the LWPC and LWPS electrode groups; the mixed model
+   `adjustment ~ group HG` with a subject random intercept is then fit for the
+   **matched** and the **cross** adjustment.
+
+### How the trial-level adjustment columns are defined
+
+`trialwise_brain_behavior` deliberately takes the adjustment columns as *input* —
+the operationalization is a design choice, so this job makes it explicit
+(`add_adjustment_columns`). Each adjustment is the trial's **signed contribution to
+the very difference-of-differences the rest of the battery is built on**:
+
+```
+adj_congruency(t) = w(t) * (RT_t − mean RT of that subject)
+w(t) = +1 for (i, high-incongruent) and (c, low-incongruent)
+       −1 for (c, high-incongruent) and (i, low-incongruent)
+```
+
+those being exactly the four cell weights of the LWPC d-o-d — so a subject's mean
+`adj_congruency` *is* their (trial-count-weighted) behavioral LWPC / 4, and a
+positive slope means "trials with more HG in this electrode group push the
+behavioral interaction harder". `adj_switch` is the same construction on
+switchType × switch_proportion. **RT and the group HG are both centered within
+subject**, so the slope is a purely within-subject quantity — with an uncentered
+predictor, between-subject differences in mean HG would leak into the common slope,
+which is exactly what the "within subject" framing is meant to exclude.
+
+## Key knobs (env vars)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `DATA_SOURCE` | `real` | `real` = epoched data + behavioral CSV; `synthetic` = ground-truth dry run. |
+| `SYNTHETIC_CROSS_FRAC` | `0.25` | synthetic only: how much of each link leaks into the WRONG pairing. `1.0` destroys specificity (the falsification run). |
+| `SYNTHETIC_ACROSS_BETA` / `SYNTHETIC_WITHIN_BETA` | `1.2` / `0.6` | synthetic only: planted coupling strengths. |
+| `BEHAVIOR_CSV` | repo-root `combinedData.csv` | raw trial-level behavior. |
+| `BEHAVIOR_RT_COL` | `RT` | RT column in that table. |
+| `WINDOW_TMIN` / `WINDOW_TMAX` | `0.0` / `0.5` | analysis window (s from stimulus onset). |
+| `ELECTRODES` | `all` | `all` or `sig`. |
+| `ALPHA` | `0.05` | A1 FDR threshold for the S/F flags. |
+| `NEURAL_SUMMARY` | `count` | which per-subject neural summary headlines the across-subject level (`count`/`frac`/`effect`); all three are computed. |
+| `RUN_TRIALWISE` | `1` | set `0` for the across-subject level only (the single-trial level needs per-trial RT in the epochs metadata). |
+
+## Outputs
+
+Written to `results/<epochs_or_synthetic_tag>/brain_behavior_window_<tmin>to<tmax>s_<electrodes>_<neural_summary>/`:
+
+- `electrode_labels.csv` — the A1 per-electrode S/F labels A6 sits on.
+- `behavioral_magnitudes.csv` — per-subject `lwpc`/`lwps` RT d-o-d (signed, ms).
+- `subject_table_<mode>.csv` — the merged neural × behavioral table per neural summary.
+- `across_subject.json` — matched and cross correlations, `n`, and the caveat.
+- `trial_df.csv` (real runs) — the single-trial table with group HG and both adjustments.
+- `trialwise.json` — matched/cross slopes, p, z, and `specificity_ok` per group.
+- `brain_behavior_summary.png` — 4 panels: both matched scatters, the across-subject
+  specificity bars, and the within-subject slopes with 95 % CIs.
+- `summary.txt` — printed verdict.
+
+**Reading:** the headline is the **specificity gap**, not a p-value. With thousands
+of trials every slope is "significant", so the claim rests on the matched pairing
+being *stronger* than the cross pairing (`specificity_ok`) at both levels. The
+across-subject correlation is reported with its *n* and an honest underpowered
+caveat — a null there is uninformative; the within-subject mixed model is the real
+test.

--- a/dcc_scripts/stats/run_stability_flexibility_brain_behavior_dcc.py
+++ b/dcc_scripts/stats/run_stability_flexibility_brain_behavior_dcc.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+"""
+Entrypoint for A6 — brain-behavior correlation: the across-subject correlation of
+neural selectivity vs. the behavioral LWPC/LWPS RT effect, and the preferred
+within-subject single-trial mixed model, each with its cross-pairing specificity
+control. Sets up input args and calls
+stability_flexibility_brain_behavior_dcc.main().
+Wrapped by sbatch_stability_flexibility_brain_behavior_dcc.sh for the cluster.
+
+Most knobs can be overridden from the submit script via environment variables
+(EPOCHS_ROOT_FILE, DATA_SOURCE, WINDOW_TMIN, WINDOW_TMAX, ELECTRODES, ALPHA,
+BEHAVIOR_CSV, BEHAVIOR_RT_COL, NEURAL_SUMMARY, RUN_TRIALWISE, SEED,
+SYNTHETIC_N_SUBJ, SYNTHETIC_ACROSS_BETA, SYNTHETIC_WITHIN_BETA,
+SYNTHETIC_CROSS_FRAC) so you can rerun without editing Python.
+"""
+import sys
+import os
+from types import SimpleNamespace
+from datetime import datetime
+
+# ---------------------------------------------------------------------------
+# PATH SETUP (detect cluster vs local, mirror the other run_* scripts)
+# ---------------------------------------------------------------------------
+if os.path.exists("/hpc/home"):
+    USER = os.environ.get('USER')
+    sys.path.append(f"/hpc/home/{USER}/coganlab/{USER}/GlobalLocal/IEEG_Pipelines/")
+    current_script_dir = os.path.dirname(os.path.abspath(__file__))
+else:
+    try:
+        current_script_dir = os.path.dirname(os.path.abspath(__file__))
+    except NameError:
+        current_script_dir = os.getcwd()
+
+project_root = os.path.abspath(os.path.join(current_script_dir, '..', '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from dcc_scripts.stats.stability_flexibility_brain_behavior_dcc import main
+
+# ---------------------------------------------------------------------------
+# ANALYSIS PARAMETERS
+# ---------------------------------------------------------------------------
+LAB_ROOT = None                      # auto-resolved in main()
+TASK = 'GlobalLocal'
+ACC_TRIALS_ONLY = True
+
+SUBJECTS = ['D0057', 'D0059', 'D0063', 'D0065', 'D0069', 'D0077', 'D0090',
+            'D0094', 'D0100', 'D0102', 'D0103', 'D0107A', 'D0110', 'D0116',
+            'D0117', 'D0121', 'D0133', 'D0134', 'D0137', 'D0138', 'D0139A',
+            'D0144', 'D0145', 'D0146']
+
+# --- data source: 'real' (epochs + behavioral CSV) or 'synthetic' (dry run) ---
+DATA_SOURCE = os.environ.get('DATA_SOURCE', 'real')
+# synthetic-only: the planted coupling strengths. CROSS_FRAC is how much of each
+# link leaks into the WRONG pairing — set it to 1.0 to destroy specificity and
+# confirm `specificity_ok` turns False.
+SYNTHETIC_N_SUBJ = int(os.environ.get('SYNTHETIC_N_SUBJ', '16'))
+SYNTHETIC_ACROSS_BETA = float(os.environ.get('SYNTHETIC_ACROSS_BETA', '1.2'))
+SYNTHETIC_WITHIN_BETA = float(os.environ.get('SYNTHETIC_WITHIN_BETA', '0.6'))
+SYNTHETIC_CROSS_FRAC = float(os.environ.get('SYNTHETIC_CROSS_FRAC', '0.25'))
+
+# --- epochs / analysis window (real data only) ---
+EPOCHS_ROOT_FILE = os.environ.get('EPOCHS_ROOT_FILE')
+if DATA_SOURCE == 'real' and EPOCHS_ROOT_FILE is None:
+    raise ValueError("EPOCHS_ROOT_FILE environment variable not set. "
+                     "Set it via sbatch --export=ALL,EPOCHS_ROOT_FILE=... "
+                     "(or run with DATA_SOURCE=synthetic to skip data loading).")
+
+WINDOW_TMIN = float(os.environ.get('WINDOW_TMIN', '0.0'))   # seconds post-stimulus
+WINDOW_TMAX = float(os.environ.get('WINDOW_TMAX', '0.5'))
+
+# --- electrode selection ---
+ELECTRODES = os.environ.get('ELECTRODES', 'all')            # 'all' or 'sig'
+ROIS_DICT = None
+
+# --- A1 hyperparameter (the electrode definition A6 sits on) ---
+ALPHA = float(os.environ.get('ALPHA', '0.05'))
+
+# --- A6 hyperparameters ---
+# Raw trial-level behavior. Defaults to the repo-root combinedData.csv; on the
+# cluster point BEHAVIOR_CSV at the Box copy.
+BEHAVIOR_CSV = os.environ.get(
+    'BEHAVIOR_CSV', os.path.join(project_root, 'combinedData.csv'))
+BEHAVIOR_RT_COL = os.environ.get('BEHAVIOR_RT_COL', 'RT')
+# which per-subject neural summary headlines the across-subject level:
+# 'count' (n_S / n_F), 'frac' (proportion of the subject's electrodes), or
+# 'effect' (mean interaction F). All three are computed; this picks the primary.
+NEURAL_SUMMARY = os.environ.get('NEURAL_SUMMARY', 'count')
+# the within-subject single-trial level needs per-trial RT in the epochs metadata;
+# set RUN_TRIALWISE=0 to run the across-subject level only.
+RUN_TRIALWISE = os.environ.get('RUN_TRIALWISE', '1') not in ('0', 'false', 'False')
+SEED = int(os.environ.get('SEED', '0'))
+
+# --- output ---
+_tag = EPOCHS_ROOT_FILE if EPOCHS_ROOT_FILE else \
+    f'synthetic_cross{SYNTHETIC_CROSS_FRAC}'
+SAVE_DIR = os.path.join(current_script_dir, 'results', _tag,
+                        f'brain_behavior_window_{WINDOW_TMIN}to{WINDOW_TMAX}s_'
+                        f'{ELECTRODES}_{NEURAL_SUMMARY}')
+
+
+def run_analysis():
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    args = SimpleNamespace(
+        timestamp=timestamp,
+        LAB_root=LAB_ROOT,
+        subjects=SUBJECTS,
+        task=TASK,
+        acc_trials_only=ACC_TRIALS_ONLY,
+        data_source=DATA_SOURCE,
+        synthetic_n_subj=SYNTHETIC_N_SUBJ,
+        synthetic_across_beta=SYNTHETIC_ACROSS_BETA,
+        synthetic_within_beta=SYNTHETIC_WITHIN_BETA,
+        synthetic_cross_frac=SYNTHETIC_CROSS_FRAC,
+        epochs_root_file=EPOCHS_ROOT_FILE,
+        window_tmin=WINDOW_TMIN,
+        window_tmax=WINDOW_TMAX,
+        electrodes=ELECTRODES,
+        rois_dict=ROIS_DICT,
+        alpha=ALPHA,
+        behavior_csv=BEHAVIOR_CSV,
+        behavior_rt_col=BEHAVIOR_RT_COL,
+        neural_summary=NEURAL_SUMMARY,
+        run_trialwise=RUN_TRIALWISE,
+        seed=SEED,
+        save_dir=SAVE_DIR,
+    )
+
+    print("=" * 78)
+    print("STABILITY vs FLEXIBILITY — A6 BRAIN-BEHAVIOR")
+    print("=" * 78)
+    print(f"Data source:      {DATA_SOURCE}"
+          + (f" (planted across_beta={SYNTHETIC_ACROSS_BETA}, "
+             f"within_beta={SYNTHETIC_WITHIN_BETA}, "
+             f"cross_frac={SYNTHETIC_CROSS_FRAC})"
+             if DATA_SOURCE == 'synthetic' else ""))
+    print(f"Subjects:         {SUBJECTS}")
+    print(f"Task:             {TASK}")
+    print(f"Epochs file:      {EPOCHS_ROOT_FILE}")
+    print(f"Behavior CSV:     {BEHAVIOR_CSV}")
+    print(f"Analysis window:  [{WINDOW_TMIN}, {WINDOW_TMAX}] s")
+    print(f"Electrodes:       {ELECTRODES}")
+    print("-" * 78)
+    print(f"alpha (A1):       {ALPHA}")
+    print(f"neural summary:   {NEURAL_SUMMARY} | trial-level: {RUN_TRIALWISE} | "
+          f"seed: {SEED}")
+    print(f"Save dir:         {SAVE_DIR}")
+    print("=" * 78)
+
+    try:
+        main(args)
+        print("\n✓ Analysis completed successfully!")
+    except Exception as e:
+        print(f"\n✗ Analysis failed with error: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    run_analysis()

--- a/dcc_scripts/stats/run_stability_flexibility_timing_dcc.py
+++ b/dcc_scripts/stats/run_stability_flexibility_timing_dcc.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+"""
+Entrypoint for A5 — relative onset of stability (LWPC) vs. flexibility (LWPS)
+information: per-bin interaction time courses, 50%-of-peak onsets, and the
+Ulrich-Miller jackknifed onset-difference test. Sets up input args and calls
+stability_flexibility_timing_dcc.main().
+Wrapped by sbatch_stability_flexibility_timing_dcc.sh for the cluster.
+
+Most knobs can be overridden from the submit script via environment variables
+(EPOCHS_ROOT_FILE, DATA_SOURCE, WINDOW_TMIN, WINDOW_TMAX, ELECTRODES, STATISTIC,
+ALPHA, SEED, SYNTHETIC_N_SUBJ, SYNTHETIC_STAB_ONSET, SYNTHETIC_FLEX_ONSET) so you
+can rerun without editing Python.
+"""
+import sys
+import os
+from types import SimpleNamespace
+from datetime import datetime
+
+# ---------------------------------------------------------------------------
+# PATH SETUP (detect cluster vs local, mirror the other run_* scripts)
+# ---------------------------------------------------------------------------
+if os.path.exists("/hpc/home"):
+    USER = os.environ.get('USER')
+    sys.path.append(f"/hpc/home/{USER}/coganlab/{USER}/GlobalLocal/IEEG_Pipelines/")
+    current_script_dir = os.path.dirname(os.path.abspath(__file__))
+else:
+    try:
+        current_script_dir = os.path.dirname(os.path.abspath(__file__))
+    except NameError:
+        current_script_dir = os.getcwd()
+
+project_root = os.path.abspath(os.path.join(current_script_dir, '..', '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from dcc_scripts.stats.stability_flexibility_timing_dcc import main
+
+# ---------------------------------------------------------------------------
+# ANALYSIS PARAMETERS
+# ---------------------------------------------------------------------------
+LAB_ROOT = None                      # auto-resolved in main()
+TASK = 'GlobalLocal'
+ACC_TRIALS_ONLY = True
+
+SUBJECTS = ['D0057', 'D0059', 'D0063', 'D0065', 'D0069', 'D0077', 'D0090',
+            'D0094', 'D0100', 'D0102', 'D0103', 'D0107A', 'D0110', 'D0116',
+            'D0117', 'D0121', 'D0133', 'D0134', 'D0137', 'D0138', 'D0139A',
+            'D0144', 'D0145', 'D0146']
+
+# --- data source: 'real' (epoched HG time courses) or 'synthetic' (dry run) ---
+DATA_SOURCE = os.environ.get('DATA_SOURCE', 'real')
+# synthetic-only: the planted onsets (seconds). Swapping these plants the REVERSE
+# ordering, which is the falsification check — the reported sign should flip.
+SYNTHETIC_N_SUBJ = int(os.environ.get('SYNTHETIC_N_SUBJ', '12'))
+SYNTHETIC_STAB_ONSET = float(os.environ.get('SYNTHETIC_STAB_ONSET', '0.20'))
+SYNTHETIC_FLEX_ONSET = float(os.environ.get('SYNTHETIC_FLEX_ONSET', '0.40'))
+
+# --- epochs / analysis window (real data only) ---
+EPOCHS_ROOT_FILE = os.environ.get('EPOCHS_ROOT_FILE')
+if DATA_SOURCE == 'real' and EPOCHS_ROOT_FILE is None:
+    raise ValueError("EPOCHS_ROOT_FILE environment variable not set. "
+                     "Set it via sbatch --export=ALL,EPOCHS_ROOT_FILE=... "
+                     "(or run with DATA_SOURCE=synthetic to skip data loading).")
+
+# A5 reads a RISING FLANK, so the window must contain the pre-onset baseline and
+# enough post-stimulus time for both effects to peak — wider than the A1/A2
+# window-mean default on purpose.
+WINDOW_TMIN = float(os.environ.get('WINDOW_TMIN', '-0.2'))   # seconds post-stimulus
+WINDOW_TMAX = float(os.environ.get('WINDOW_TMAX', '0.8'))
+
+# --- electrode selection ---
+ELECTRODES = os.environ.get('ELECTRODES', 'all')            # 'all' or 'sig'
+ROIS_DICT = None
+
+# --- A5 hyperparameters ---
+# 'mean' = grand-average the per-electrode d-o-d(t) (the information time course);
+# 't'    = noise-normalized t across electrodes, often a cleaner rising flank.
+STATISTIC = os.environ.get('STATISTIC', 'mean')
+ALPHA = float(os.environ.get('ALPHA', '0.05'))
+SEED = int(os.environ.get('SEED', '0'))
+
+# --- output ---
+_tag = EPOCHS_ROOT_FILE if EPOCHS_ROOT_FILE else \
+    f'synthetic_onsets{SYNTHETIC_STAB_ONSET}v{SYNTHETIC_FLEX_ONSET}'
+SAVE_DIR = os.path.join(current_script_dir, 'results', _tag,
+                        f'timing_window_{WINDOW_TMIN}to{WINDOW_TMAX}s_'
+                        f'{ELECTRODES}_{STATISTIC}')
+
+
+def run_analysis():
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    args = SimpleNamespace(
+        timestamp=timestamp,
+        LAB_root=LAB_ROOT,
+        subjects=SUBJECTS,
+        task=TASK,
+        acc_trials_only=ACC_TRIALS_ONLY,
+        data_source=DATA_SOURCE,
+        synthetic_n_subj=SYNTHETIC_N_SUBJ,
+        synthetic_stab_onset=SYNTHETIC_STAB_ONSET,
+        synthetic_flex_onset=SYNTHETIC_FLEX_ONSET,
+        epochs_root_file=EPOCHS_ROOT_FILE,
+        window_tmin=WINDOW_TMIN,
+        window_tmax=WINDOW_TMAX,
+        electrodes=ELECTRODES,
+        rois_dict=ROIS_DICT,
+        statistic=STATISTIC,
+        alpha=ALPHA,
+        seed=SEED,
+        save_dir=SAVE_DIR,
+    )
+
+    print("=" * 70)
+    print("STABILITY vs FLEXIBILITY — A5 TIMING (relative onset)")
+    print("=" * 70)
+    print(f"Data source:      {DATA_SOURCE}"
+          + (f" (planted onsets LWPC={SYNTHETIC_STAB_ONSET}s, "
+             f"LWPS={SYNTHETIC_FLEX_ONSET}s)" if DATA_SOURCE == 'synthetic' else ""))
+    print(f"Subjects:         {SUBJECTS}")
+    print(f"Task:             {TASK}")
+    print(f"Epochs file:      {EPOCHS_ROOT_FILE}")
+    print(f"Analysis window:  [{WINDOW_TMIN}, {WINDOW_TMAX}] s")
+    print(f"Electrodes:       {ELECTRODES}")
+    print("-" * 70)
+    print(f"statistic:        {STATISTIC} | alpha: {ALPHA} | seed: {SEED}")
+    print(f"Save dir:         {SAVE_DIR}")
+    print("=" * 70)
+
+    try:
+        main(args)
+        print("\n✓ Analysis completed successfully!")
+    except Exception as e:
+        print(f"\n✗ Analysis failed with error: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    run_analysis()

--- a/dcc_scripts/stats/sbatch_stability_flexibility_brain_behavior_dcc.sh
+++ b/dcc_scripts/stats/sbatch_stability_flexibility_brain_behavior_dcc.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#SBATCH --output=out/slurm_%j.out
+#SBATCH -e out/slurm_%j.err
+#SBATCH -p common,scavenger,coganlab-gpu
+#SBATCH -c 8
+#SBATCH --mem=64G
+#SBATCH --time=12:00:00
+
+source $(conda info --base)/etc/profile.d/conda.sh
+
+conda activate ieeg  # needs scipy + statsmodels (mixedlm) + mne
+
+python /hpc/home/$USER/coganlab/$USER/GlobalLocal/dcc_scripts/stats/run_stability_flexibility_brain_behavior_dcc.py

--- a/dcc_scripts/stats/sbatch_stability_flexibility_timing_dcc.sh
+++ b/dcc_scripts/stats/sbatch_stability_flexibility_timing_dcc.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#SBATCH --output=out/slurm_%j.out
+#SBATCH -e out/slurm_%j.err
+#SBATCH -p common,scavenger,coganlab-gpu
+#SBATCH -c 8
+#SBATCH --mem=128G
+#SBATCH --time=12:00:00
+
+source $(conda info --base)/etc/profile.d/conda.sh
+
+conda activate ieeg  # needs scipy + statsmodels + mne
+
+python /hpc/home/$USER/coganlab/$USER/GlobalLocal/dcc_scripts/stats/run_stability_flexibility_timing_dcc.py

--- a/dcc_scripts/stats/stability_flexibility_brain_behavior_dcc.py
+++ b/dcc_scripts/stats/stability_flexibility_brain_behavior_dcc.py
@@ -1,0 +1,648 @@
+#!/usr/bin/env python
+"""
+DCC core for A6 — brain-behavior correlation
+(`docs/stability_flexibility_guide.md` §6).
+
+Ties the A1 neural selectivity to the ACTUAL behavioral control adjustment, so the
+substrates are shown to be *functional* rather than incidental. Two levels with
+very different power, both run here:
+
+  (1) ACROSS SUBJECTS (n = subjects, honest but underpowered): does a subject with
+      more/stronger LWPC electrodes show a larger behavioral LWPC (congruency x
+      incongruent-proportion) RT effect, and likewise LWPS?
+      -> `sbb.subject_level_brain_behavior`
+  (2) WITHIN SUBJECT, SINGLE TRIAL (preferred, far more power): does trial-by-trial
+      HG in the LWPC electrode group predict the trial-by-trial congruency
+      adjustment (LWPS group <-> switch adjustment), via a mixed model with a
+      subject random intercept?
+      -> `sbb.trialwise_brain_behavior`
+
+The MATCHED pairing should beat the CROSS pairing (LWPC group <-> switch
+adjustment, and vice versa). That gap is the specificity result and the whole point
+of A6, so both functions report the cross pairing alongside the matched one.
+
+Pipeline:
+  1. Assemble the same window-mean long table as the A1/A2/A3 jobs
+     (`assemble_long_df`, contrast_mode='proportion') and run the A1 electrode
+     definition (`sfs.per_electrode_anova_labels`) -> per-electrode S/F flags.
+  2. Behavior: per-subject LWPC/LWPS RT magnitudes from the raw behavioral table
+     (`combinedData.csv` by default) via `sbb.behavioral_lwpc_lwps_magnitudes` --
+     the SAME equal-cell-weight difference-of-differences used for the neural
+     interaction, so brain and behavior are measured on the identical contrast.
+  3. Across-subject correlations for each neural summary ('count', 'frac', and the
+     mean interaction F), each with its cross-pairing control.
+  4. Single-trial table (`assemble_trial_table`): per (subject, trial) RT plus the
+     HG averaged over the LWPC and LWPS electrode groups, then the mixed models.
+
+The trial-level adjustment columns
+----------------------------------
+`sbb.trialwise_brain_behavior` deliberately takes the behavioral adjustment columns
+as INPUT -- it does not define them, because the operationalization is a design
+choice. This job defines them as each trial's SIGNED CONTRIBUTION to the very
+difference-of-differences the rest of the battery is built on (`_adjustment_weight`
+/ `add_adjustment_columns`):
+
+    adj_congruency(t) = w(t) * (RT_t - mean RT of that subject)
+    w(t) = +1 for (i, high-incongruent) and (c, low-incongruent)
+           -1 for (c, high-incongruent) and (i, low-incongruent)
+
+Those are exactly the four cell weights of the LWPC d-o-d, so a trial's `adj` is
+large when its RT pushes the interaction in its own direction, and the mean of
+`adj` over a subject's trials is that subject's (trial-count-weighted) LWPC/4. A
+positive mixed-model slope therefore means "trials with more HG in this electrode
+group push the behavioral interaction harder" -- the functional claim A6 makes.
+`adj_switch` is the same construction on switchType x switch_proportion.
+
+RT and the group HG are both CENTERED WITHIN SUBJECT, so the slope is a purely
+within-subject effect: with an uncentered predictor a between-subject difference in
+mean HG would leak into the common slope, which is precisely the confound the
+"within subject" framing is supposed to exclude.
+
+On the SYNTHETIC path `sbb._synthetic_brain_behavior` plants a matched
+across-subject correlation AND a matched within-subject coupling, each stronger
+than its cross control, so the whole path is validated against ground truth in
+seconds with no data on disk.
+
+Driven by `run_stability_flexibility_brain_behavior_dcc.py` (wrapped by
+`sbatch_stability_flexibility_brain_behavior_dcc.sh`). Not run directly on the
+cluster; call `main(args)` with a populated argument namespace.
+"""
+
+import warnings
+warnings.simplefilter(action='ignore', category=FutureWarning)
+
+import sys
+import os
+import json
+
+# ---------------------------------------------------------------------------
+# PATH SETUP (mirrors the other dcc_scripts entrypoints)
+# ---------------------------------------------------------------------------
+try:
+    current_file_path = os.path.abspath(__file__)
+    current_script_dir = os.path.dirname(current_file_path)
+except NameError:
+    current_script_dir = os.getcwd()
+
+project_root = os.path.abspath(os.path.join(current_script_dir, '..', '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+if os.path.exists("/hpc/home"):
+    USER = os.environ.get('USER')
+    sys.path.append(f"/hpc/home/{USER}/coganlab/{USER}/GlobalLocal/IEEG_Pipelines/")
+
+import numpy as np
+import pandas as pd
+
+import matplotlib
+matplotlib.use('Agg')          # headless / cluster
+import matplotlib.pyplot as plt
+
+from src.analysis.stats import stability_flexibility_segregation as sfs
+from src.analysis.stats import stability_flexibility_brain_behavior as sbb
+
+# NOTE: `general_utils` and the sibling DCC core pull in the mne / ieeg stack at
+# import time and are only reachable on the real-data path, so they are imported
+# lazily inside `main` -- the `DATA_SOURCE=synthetic` dry run then validates this
+# job's own logic anywhere the analysis modules import.
+
+# A6 sits on the A1 electrodes: LWPC/LWPS interactions on window-mean HG.
+CONTRAST_MODE = 'proportion'
+EFFECT_MEASURE = 'cohens_d'
+
+STAB, FLEX = "#2c7fb8", "#d95f0e"
+
+# the neural summaries correlated against behavior, and the label columns each needs
+_NEURAL_MODES = (('count', 'n_S / n_F  (# selective electrodes)'),
+                 ('frac', 'frac_S / frac_F  (proportion of the subject\'s electrodes)'),
+                 ('effect', 'mean_stab / mean_flex  (mean interaction F)'))
+
+
+# ---------------------------------------------------------------------------
+# behavior
+# ---------------------------------------------------------------------------
+def load_behavior(csv_path, subject_col='subject_ID', rt_col='RT'):
+    """Per-subject behavioral LWPC/LWPS magnitudes from the raw trial table.
+
+    `combinedData.csv` names the subject column `subject_ID`; the analysis module
+    expects `subject`, so it is renamed here rather than in the module."""
+    if not os.path.exists(csv_path):
+        raise FileNotFoundError(
+            f"behavioral table not found at {csv_path}. Point BEHAVIOR_CSV at the "
+            "raw trial-level behavior (the repo-root `combinedData.csv`, or the "
+            "Box copy on the cluster).")
+    raw = pd.read_csv(csv_path)
+    if subject_col in raw.columns and 'subject' not in raw.columns:
+        raw = raw.rename(columns={subject_col: 'subject'})
+    missing = [c for c in ('subject', rt_col, 'congruency', 'switchType')
+               if c not in raw.columns]
+    if missing:
+        raise KeyError(f"behavioral table {csv_path} is missing columns {missing}; "
+                       f"it has {list(raw.columns)}")
+    behavior = sbb.behavioral_lwpc_lwps_magnitudes(raw, rt_col=rt_col)
+    return raw, behavior
+
+
+# ---------------------------------------------------------------------------
+# single-trial table (real data): RT + per-trial HG for each electrode group
+# ---------------------------------------------------------------------------
+# metadata column aliases -- the event-name parser emits the first of each pair,
+# but a metadata CSV attached upstream may already use the short name.
+_RT_COLS = ('reaction_time', 'RT', 'rt')
+_ACC_COLS = ('accuracy', 'acc')
+_SWITCH_COLS = ('task_sequence', 'switchType')
+
+
+def _first_col(md, names):
+    for n in names:
+        if n in md.columns:
+            return n
+    return None
+
+
+def assemble_trial_table(subjects_epochs, tmin, tmax, electrodes_to_keep=None):
+    """Per-(subject, trial) behavior + the per-channel window-mean HG behind it.
+
+    Returns ``(trials, hg_by_subject)``:
+      trials         one row per (subject, trial) with `subject`, `trial`, `RT`,
+                     `acc`, `congruency`, `switchType`, and the two proportion
+                     columns. Rows keep their per-subject order so they align with
+                     the HG matrices below.
+      hg_by_subject  {subject: (electrode_ids, ndarray (n_trials, n_channels))},
+                     the window mean of HG over [tmin, tmax] per trial per channel.
+                     `electrode_ids` use the same `f"{subject}-{channel}"` naming as
+                     the A1 labels so the two can be joined directly.
+
+    Trials with an unusable congruency label are dropped (they can't contribute to
+    either adjustment); a `switchType` outside {'s','r'} — the first-of-block `n` —
+    is kept but yields a NaN switch adjustment, which the models drop per-column.
+    """
+    from dcc_scripts.stats.stability_flexibility_segregation_dcc import (
+        _window_indices, _proportion_col)
+
+    frames, hg_by_subject = [], {}
+    for sub, epochs in subjects_epochs.items():
+        md = epochs.metadata
+        if md is None or 'congruency' not in md.columns:
+            from src.analysis.utils.epoch_metadata_utils import make_metadata_from_event_names
+            md = make_metadata_from_event_names(epochs)
+
+        rt_col = _first_col(md, _RT_COLS)
+        if rt_col is None:
+            raise KeyError(
+                f"subject {sub}: epochs metadata has no reaction-time column "
+                f"(looked for {_RT_COLS}); the within-subject single-trial level of "
+                f"A6 needs per-trial RT. Columns present: {list(md.columns)}")
+        acc_col = _first_col(md, _ACC_COLS)
+        sw_col = _first_col(md, _SWITCH_COLS)
+
+        cong = md['congruency'].to_numpy().astype(str)
+        sw = md[sw_col].to_numpy().astype(str) if sw_col else np.full(len(md), 'n')
+        keep = np.isin(cong, ['c', 'i'])
+
+        times = np.asarray(epochs.times, float)
+        s_idx, e_idx = _window_indices(times, tmin, tmax)
+        hg_mean = np.nanmean(epochs.get_data()[:, :, s_idx:e_idx], axis=2)  # (trial, chan)
+        ch_names = list(epochs.ch_names)
+        if electrodes_to_keep is not None:
+            wanted = electrodes_to_keep.get(sub, set())
+            ch_idx = [i for i, ch in enumerate(ch_names) if ch in wanted]
+        else:
+            ch_idx = list(range(len(ch_names)))
+
+        frames.append(pd.DataFrame(dict(
+            subject=sub,
+            trial=np.arange(len(md))[keep],
+            RT=pd.to_numeric(md[rt_col], errors='coerce').to_numpy()[keep],
+            acc=(pd.to_numeric(md[acc_col], errors='coerce').to_numpy()[keep]
+                 if acc_col else np.nan),
+            congruency=cong[keep],
+            switchType=sw[keep],
+            incongruent_proportion=_proportion_col(md, 'incongruent_proportion')[keep],
+            switch_proportion=_proportion_col(md, 'switch_proportion')[keep])))
+        hg_by_subject[sub] = ([f"{sub}-{ch_names[i]}" for i in ch_idx],
+                              hg_mean[np.ix_(keep, ch_idx)])
+
+    if not frames:
+        raise RuntimeError("assembled 0 trials — check subjects / window / metadata")
+    return pd.concat(frames, ignore_index=True), hg_by_subject
+
+
+def attach_group_hg(trials, hg_by_subject, labels, flag_cols=(('S', 'hg_lwpc'),
+                                                             ('F', 'hg_lwps'))):
+    """Average each trial's HG over the A1 LWPC (S) and LWPS (F) electrode groups.
+
+    A subject with no electrode in a group gets NaN for that column (the mixed
+    model drops those rows), which is the honest outcome — that subject carries no
+    information about the group's trial-by-trial coupling."""
+    out = trials.copy()
+    for flag, col in flag_cols:
+        values = np.full(len(out), np.nan)
+        for sub, (elec_ids, hg) in hg_by_subject.items():
+            sel = labels[(labels['subject'] == sub) & (labels[flag] == 1)]
+            wanted = set(sel['electrode'])
+            idx = [i for i, e in enumerate(elec_ids) if e in wanted]
+            if not idx:
+                continue
+            rows = (out['subject'] == sub).to_numpy()
+            with warnings.catch_warnings():        # all-NaN channel slices are fine
+                warnings.simplefilter('ignore', category=RuntimeWarning)
+                values[rows] = np.nanmean(hg[:, idx], axis=1)
+        out[col] = values
+    return out
+
+
+# ---------------------------------------------------------------------------
+# the trial-level behavioral adjustments (see the module docstring)
+# ---------------------------------------------------------------------------
+def _adjustment_weight(cond, mod, pos, neg):
+    """The trial's cell weight in the equal-cell-weight difference-of-differences:
+    +1 on the (pos, high) and (neg, low) diagonal, -1 on the other, NaN if the trial
+    falls in neither (an unusable condition label or a missing proportion)."""
+    num = pd.to_numeric(pd.Series(mod), errors='coerce').to_numpy()
+    finite = num[np.isfinite(num)]
+    if finite.size == 0:
+        return np.full(len(num), np.nan)
+    hi, lo = float(np.max(finite)), float(np.min(finite))
+    if hi == lo:                       # only one block level present: no interaction
+        return np.full(len(num), np.nan)
+    cond = np.asarray(cond).astype(str)
+    cond_sign = np.where(cond == pos, 1.0, np.where(cond == neg, -1.0, np.nan))
+    mod_sign = np.where(np.isclose(num, hi), 1.0,
+                        np.where(np.isclose(num, lo), -1.0, np.nan))
+    return cond_sign * mod_sign
+
+
+def add_adjustment_columns(trials, rt_col='RT', center_cols=('hg_lwpc', 'hg_lwps'),
+                           correct_only=True):
+    """Attach `adj_congruency` / `adj_switch` and subject-center RT and group HG.
+
+    Each adjustment is the trial's SIGNED CONTRIBUTION to its process's
+    difference-of-differences: the d-o-d cell weight times the subject-centered RT.
+    Centering RT (and the HG predictors) within subject keeps the mixed-model slope
+    a purely WITHIN-subject quantity — an uncentered predictor would let
+    between-subject differences in mean HG contribute to the common slope."""
+    d = trials.copy()
+    if correct_only and 'acc' in d.columns and d['acc'].notna().any():
+        d = d[d['acc'] == 1]
+    d[rt_col] = pd.to_numeric(d[rt_col], errors='coerce')
+    d = d[d[rt_col].notna()].reset_index(drop=True)
+
+    rt_centered = d[rt_col] - d.groupby('subject')[rt_col].transform('mean')
+    d['rt_centered'] = rt_centered
+    d['w_congruency'] = _adjustment_weight(
+        d['congruency'], d['incongruent_proportion'], 'i', 'c')
+    d['w_switch'] = _adjustment_weight(
+        d['switchType'], d['switch_proportion'], 's', 'r')
+    d['adj_congruency'] = d['w_congruency'] * rt_centered
+    d['adj_switch'] = d['w_switch'] * rt_centered
+
+    for col in center_cols:
+        if col in d.columns:
+            d[col] = d[col] - d.groupby('subject')[col].transform('mean')
+    return d
+
+
+# ---------------------------------------------------------------------------
+# serialization
+# ---------------------------------------------------------------------------
+def _json_safe(o):
+    if isinstance(o, (np.floating, np.integer)):
+        return o.item()
+    if isinstance(o, (np.bool_, bool)):
+        return bool(o)
+    if isinstance(o, np.ndarray):
+        return o.tolist()
+    if isinstance(o, (list, tuple)):
+        return [_json_safe(v) for v in o]
+    if isinstance(o, dict):
+        return {k: _json_safe(v) for k, v in o.items()}
+    return o
+
+
+def save_results(labels, behavior, across, trialwise, save_dir):
+    os.makedirs(save_dir, exist_ok=True)
+    labels.to_csv(os.path.join(save_dir, 'electrode_labels.csv'), index=False)
+    behavior.to_csv(os.path.join(save_dir, 'behavioral_magnitudes.csv'), index=False)
+
+    payload = {}
+    for mode, res in across.items():
+        res = dict(res)
+        table = res.pop('table')
+        table.to_csv(os.path.join(save_dir, f'subject_table_{mode}.csv'), index=False)
+        payload[mode] = res
+    with open(os.path.join(save_dir, 'across_subject.json'), 'w') as f:
+        json.dump(_json_safe(payload), f, indent=2)
+
+    with open(os.path.join(save_dir, 'trialwise.json'), 'w') as f:
+        json.dump(_json_safe(trialwise), f, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# figures
+# ---------------------------------------------------------------------------
+def _slope_ci(slope, z):
+    """95% CI from the mixed model's slope and z (SE = |slope / z|)."""
+    if not np.isfinite(slope) or not np.isfinite(z) or z == 0:
+        return np.nan
+    return 1.96 * abs(slope / z)
+
+
+def make_plots(across, trialwise, save_dir, primary='count'):
+    res = across[primary]
+    m = res['table']
+    s_col, f_col = {'count': ('n_S', 'n_F'), 'frac': ('frac_S', 'frac_F'),
+                    'effect': ('mean_stab', 'mean_flex')}[primary]
+
+    fig, ax = plt.subplots(1, 4, figsize=(19, 4.2))
+
+    # (1-2) the two MATCHED across-subject scatters
+    for a, xcol, ycol, colour, name, r, p in (
+            (ax[0], s_col, 'lwpc', STAB, 'LWPC (stability)',
+             res['corr_lwpc'], res['p_lwpc']),
+            (ax[1], f_col, 'lwps', FLEX, 'LWPS (flexibility)',
+             res['corr_lwps'], res['p_lwps'])):
+        a.scatter(m[xcol], m[ycol], color=colour)
+        a.set(title=f"A6 · matched {name}\nr = {r:.2f}  p = {p:.3g}  "
+                    f"n = {res['n_subjects']}",
+              xlabel=f"neural: {xcol}", ylabel=f"behavioral {ycol} (RT d-o-d)")
+
+    # (3) across-subject specificity: matched vs cross |r|
+    pairs = [('LWPC neural\n↔ LWPC RT', abs(res['corr_lwpc']), STAB, 'matched'),
+             ('LWPC neural\n↔ LWPS RT', abs(res['corr_cross_stab_lwps']), STAB, 'cross'),
+             ('LWPS neural\n↔ LWPS RT', abs(res['corr_lwps']), FLEX, 'matched'),
+             ('LWPS neural\n↔ LWPC RT', abs(res['corr_cross_flex_lwpc']), FLEX, 'cross')]
+    xs = np.arange(len(pairs))
+    for i, p in enumerate(pairs):                 # one call per bar: alpha is per-bar
+        ax[2].bar(i, p[1], color=p[2], alpha=1.0 if p[3] == 'matched' else 0.3,
+                  edgecolor='k', linewidth=0.6)
+    ax[2].set_xticks(xs); ax[2].set_xticklabels([p[0] for p in pairs], fontsize=7)
+    ax[2].set(title=f"A6 · across-subject specificity ({primary})\n"
+                    "solid = matched, faded = cross control",
+              ylabel="|Pearson r|")
+
+    # (4) within-subject slopes: matched vs cross, with 95% CI
+    labels_, vals, errs, colours, alphas = [], [], [], [], []
+    for group, colour in (('LWPC', STAB), ('LWPS', FLEX)):
+        r = trialwise.get(group)
+        if r is None:
+            continue
+        labels_ += [f"{group}\nmatched", f"{group}\ncross"]
+        vals += [r['slope'], r['slope_cross']]
+        errs += [_slope_ci(r['slope'], r['z']), _slope_ci(r['slope_cross'], r['z_cross'])]
+        colours += [colour, colour]
+        alphas += [1.0, 0.3]
+    if vals:
+        xs = np.arange(len(vals))
+        for i in xs:
+            ax[3].bar(i, vals[i], yerr=errs[i], color=colours[i], alpha=alphas[i],
+                      edgecolor='k', linewidth=0.6, capsize=4)
+        ax[3].set_xticks(xs); ax[3].set_xticklabels(labels_, fontsize=7)
+        ax[3].axhline(0, color='k', lw=0.6)
+        ax[3].set(title="A6 · within-subject single-trial slopes\n"
+                        "(mixedlm, subject random intercept; 95% CI)",
+                  ylabel="slope: adjustment per unit group HG")
+    else:
+        ax[3].text(0.5, 0.5, "within-subject level not run\n(see summary.txt)",
+                   ha='center', va='center', transform=ax[3].transAxes)
+        ax[3].set_axis_off()
+
+    fig.tight_layout()
+    fig.savefig(os.path.join(save_dir, 'brain_behavior_summary.png'), dpi=140,
+                bbox_inches='tight')
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# text summary
+# ---------------------------------------------------------------------------
+def write_summary(labels, behavior, across, trialwise, save_dir, meta,
+                  primary='count', notes=(), alpha=0.05):
+    lines = [
+        "=" * 78,
+        "STABILITY vs FLEXIBILITY — A6 BRAIN-BEHAVIOR",
+        "=" * 78,
+    ]
+    for k, v in meta.items():
+        lines.append(f"{k:>22}: {v}")
+    lines += [
+        "-" * 78,
+        f"electrodes: {len(labels)} | S (LWPC) = {int(labels['S'].sum())} | "
+        f"F (LWPS) = {int(labels['F'].sum())} | "
+        f"both = {int(((labels['S'] == 1) & (labels['F'] == 1)).sum())}",
+        f"behavioral magnitudes: {len(behavior)} subjects | "
+        f"mean LWPC = {np.nanmean(behavior['lwpc']):.1f} ms | "
+        f"mean LWPS = {np.nanmean(behavior['lwps']):.1f} ms",
+        "-" * 78,
+        "(1) ACROSS SUBJECTS — underpowered by design; supporting, not decisive",
+    ]
+    for mode, desc in _NEURAL_MODES:
+        res = across.get(mode)
+        if res is None:
+            continue
+        star = " <- primary" if mode == primary else ""
+        matched_beats_cross = (abs(res['corr_lwpc']) > abs(res['corr_cross_stab_lwps'])
+                               and abs(res['corr_lwps']) > abs(res['corr_cross_flex_lwpc']))
+        lines += [
+            f"      neural = {mode!r} ({desc}){star}",
+            f"          MATCHED  LWPC neural ↔ LWPC RT : r = {res['corr_lwpc']:+.3f}  "
+            f"p = {res['p_lwpc']:.4g}",
+            f"          MATCHED  LWPS neural ↔ LWPS RT : r = {res['corr_lwps']:+.3f}  "
+            f"p = {res['p_lwps']:.4g}",
+            f"          CROSS    LWPC neural ↔ LWPS RT : r = {res['corr_cross_stab_lwps']:+.3f}  "
+            f"p = {res['p_cross_stab_lwps']:.4g}",
+            f"          CROSS    LWPS neural ↔ LWPC RT : r = {res['corr_cross_flex_lwpc']:+.3f}  "
+            f"p = {res['p_cross_flex_lwpc']:.4g}",
+            f"          specificity (both matched |r| > their cross |r|): "
+            f"{matched_beats_cross}",
+        ]
+    primary_res = across.get(primary)
+    if primary_res is not None:
+        lines.append(f"      n = {primary_res['n_subjects']} subjects. "
+                     f"{primary_res['caveat']}")
+
+    lines += [
+        "-" * 78,
+        "(2) WITHIN SUBJECT, SINGLE TRIAL — the powered test",
+        "      model: adjustment ~ group HG, subject random intercept (mixedlm);",
+        "      adjustment = the trial's signed contribution to its process's",
+        "      difference-of-differences (d-o-d cell weight x subject-centered RT).",
+    ]
+    if trialwise:
+        for group in ('LWPC', 'LWPS'):
+            r = trialwise.get(group)
+            if r is None:
+                continue
+            lines += [
+                f"      [{group}]  n_trials = {r['n_trials']}  n_subjects = {r['n_subjects']}",
+                f"          MATCHED ({r['matched_adjustment']}): slope = {r['slope']:+.4f}  "
+                f"p = {r['p']:.4g}  z = {r['z']:.2f}",
+                f"          CROSS   ({r['cross_adjustment']}): slope = {r['slope_cross']:+.4f}  "
+                f"p = {r['p_cross']:.4g}  z = {r['z_cross']:.2f}",
+                f"          specificity_ok (|matched| > |cross|): {r['specificity_ok']}",
+            ]
+    else:
+        lines.append("      NOT RUN — see the notes below.")
+    for note in notes:
+        lines.append(f"      NOTE: {note}")
+
+    lines += [
+        "=" * 78,
+        "Reading: the headline is the SPECIFICITY GAP, not a p-value. With thousands",
+        "of trials every slope is 'significant', so the claim rests on the matched",
+        "pairing being STRONGER than the cross pairing (`specificity_ok`), at both",
+        "levels. The across-subject correlation is reported with its n and an honest",
+        "underpowered caveat — a null there is uninformative; the within-subject",
+        "mixed model is the real test.",
+    ]
+    txt = "\n".join(str(x) for x in lines)
+    with open(os.path.join(save_dir, 'summary.txt'), 'w') as f:
+        f.write(txt + "\n")
+    print(txt)
+
+
+# ---------------------------------------------------------------------------
+# orchestrator
+# ---------------------------------------------------------------------------
+def main(args):
+    alpha = getattr(args, 'alpha', 0.05)
+    primary = getattr(args, 'neural_summary', 'count')
+    run_trialwise = getattr(args, 'run_trialwise', True)
+    notes = []
+
+    print(f"contrast_mode: {CONTRAST_MODE} | effect_measure: {EFFECT_MEASURE}")
+    os.makedirs(args.save_dir, exist_ok=True)
+
+    trial_df = None
+    if args.data_source == 'synthetic':
+        print("DATA SOURCE: synthetic (pipeline / path validation)")
+        labels, behavior, trial_df = sbb._synthetic_brain_behavior(
+            n_subj=getattr(args, 'synthetic_n_subj', 16),
+            seed=getattr(args, 'seed', 0),
+            across_beta=getattr(args, 'synthetic_across_beta', 1.2),
+            within_beta=getattr(args, 'synthetic_within_beta', 0.6),
+            cross_frac=getattr(args, 'synthetic_cross_frac', 0.25))
+        hg_cols = dict(LWPC='hg_lwpc', LWPS='hg_lwps')
+        print(f"synthetic: {len(labels)} electrodes | {len(behavior)} subjects | "
+              f"{len(trial_df)} trials (planted matched > cross at both levels)")
+    else:
+        print("DATA SOURCE: real epoched data + behavioral table")
+        from src.analysis.utils.general_utils import (
+            resolve_lab_root, resolve_electrodes_to_keep,
+            load_HG_ev1_rescaled_per_subject)
+        # reuse the SAME long-format assembly as the sibling A1/A2/A3 jobs
+        from dcc_scripts.stats.stability_flexibility_segregation_dcc import assemble_long_df
+
+        LAB_root = resolve_lab_root(args.LAB_root)
+        print(f"LAB_root: {LAB_root}")
+        subjects_epochs = load_HG_ev1_rescaled_per_subject(
+            subjects=args.subjects, epochs_root_file=args.epochs_root_file,
+            task=args.task, LAB_root=LAB_root, acc_trials_only=args.acc_trials_only)
+        keep = resolve_electrodes_to_keep(args, LAB_root)
+
+        # 1. A1 electrode definition ----------------------------------------------
+        df = assemble_long_df(subjects_epochs, args.window_tmin, args.window_tmax,
+                              electrodes_to_keep=keep, effect_measure=EFFECT_MEASURE)
+        print(f"assembled df: {len(df)} rows | {df.subject.nunique()} subjects | "
+              f"{df.electrode.nunique()} electrodes")
+        for col in ('incongruent_proportion', 'switch_proportion'):
+            if col not in df.columns or df[col].isna().all():
+                raise RuntimeError(
+                    f"df is missing usable '{col}' — A6 correlates behavior against "
+                    "the A1 (proportion) electrode definition, which needs the "
+                    "block-proportion columns.")
+        df.to_csv(os.path.join(args.save_dir, 'long_df.csv'), index=False)
+
+        print("A1: per-electrode two-way interaction ANOVA (Type III, FDR across electrodes)")
+        labels = sfs.per_electrode_anova_labels(
+            df, alpha=alpha, contrast_mode=CONTRAST_MODE)
+
+        # 2. behavior ---------------------------------------------------------------
+        print(f"behavior: {args.behavior_csv}")
+        _, behavior = load_behavior(args.behavior_csv, rt_col=args.behavior_rt_col)
+        shared = set(behavior['subject']) & set(labels['subject'])
+        print(f"behavioral magnitudes: {len(behavior)} subjects | "
+              f"{len(shared)} also have neural labels")
+        if not shared:
+            raise RuntimeError(
+                "no subject appears in BOTH the behavioral table and the neural "
+                f"labels. Behavioral subjects: {sorted(set(behavior['subject']))[:8]}... "
+                f"neural subjects: {sorted(set(labels['subject']))[:8]}... — check "
+                "that the two use the same subject-ID convention.")
+
+        # 3. single-trial table for the within-subject level -------------------------
+        if run_trialwise:
+            try:
+                trials, hg_by_subject = assemble_trial_table(
+                    subjects_epochs, args.window_tmin, args.window_tmax,
+                    electrodes_to_keep=keep)
+                trials = attach_group_hg(trials, hg_by_subject, labels)
+                trial_df = add_adjustment_columns(trials)
+                trial_df.to_csv(os.path.join(args.save_dir, 'trial_df.csv'), index=False)
+                print(f"single-trial table: {len(trial_df)} trials | "
+                      f"{trial_df.subject.nunique()} subjects")
+            except (KeyError, RuntimeError) as e:
+                notes.append(f"single-trial level skipped: {e}")
+                print(f"WARNING: single-trial level skipped: {e}")
+                trial_df = None
+        else:
+            notes.append("single-trial level disabled (RUN_TRIALWISE=0)")
+        hg_cols = dict(LWPC='hg_lwpc', LWPS='hg_lwps')
+
+    # 4. across-subject correlations (every neural summary, each with its cross) ----
+    print("A6 (1): across-subject correlations + cross-pairing controls")
+    across = {}
+    for mode, _desc in _NEURAL_MODES:
+        try:
+            across[mode] = sbb.subject_level_brain_behavior(
+                labels, behavior, neural=mode,
+                stab_effect='F_cong', flex_effect='F_switch')
+        except KeyError as e:
+            notes.append(f"across-subject neural={mode!r} skipped: {e}")
+    if primary not in across:
+        raise RuntimeError(f"the primary neural summary {primary!r} could not be "
+                           f"computed; available: {sorted(across)}")
+    for mode, res in across.items():
+        print(f"      [{mode}] matched r: LWPC={res['corr_lwpc']:+.3f} "
+              f"LWPS={res['corr_lwps']:+.3f} | cross r: "
+              f"{res['corr_cross_stab_lwps']:+.3f} / {res['corr_cross_flex_lwpc']:+.3f}")
+
+    # 5. within-subject single-trial mixed models -----------------------------------
+    trialwise = {}
+    if trial_df is not None:
+        print("A6 (2): within-subject single-trial mixed models (matched vs cross)")
+        for group, hg_col in hg_cols.items():
+            usable = trial_df[[hg_col, 'adj_congruency', 'adj_switch']].dropna(
+                subset=[hg_col])
+            if usable.empty:
+                notes.append(f"{group} trial-level model skipped: no trial has HG in "
+                             f"the {group} electrode group")
+                continue
+            try:
+                trialwise[group] = sbb.trialwise_brain_behavior(
+                    trial_df, group=group, hg_col=hg_col)
+                r = trialwise[group]
+                print(f"      [{group}] matched slope={r['slope']:+.4f} "
+                      f"(p={r['p']:.3g}) | cross slope={r['slope_cross']:+.4f} "
+                      f"(p={r['p_cross']:.3g}) | specificity_ok={r['specificity_ok']}")
+            except Exception as e:                 # a singular fit is informative, not fatal
+                notes.append(f"{group} trial-level model failed: {type(e).__name__}: {e}")
+                print(f"WARNING: {group} trial-level model failed: {e}")
+
+    # 6. persist + plot + summarize --------------------------------------------------
+    save_results(labels, behavior, across, trialwise, args.save_dir)
+    make_plots(across, trialwise, args.save_dir, primary=primary)
+    write_summary(labels, behavior, across, trialwise, args.save_dir, notes=notes,
+                  primary=primary, alpha=alpha,
+                  meta=dict(
+                      data_source=args.data_source, task=args.task,
+                      epochs_root_file=getattr(args, 'epochs_root_file', None),
+                      behavior_csv=getattr(args, 'behavior_csv', None),
+                      window=f"[{getattr(args, 'window_tmin', None)}, "
+                             f"{getattr(args, 'window_tmax', None)}]s",
+                      contrast_mode=CONTRAST_MODE, effect_measure=EFFECT_MEASURE,
+                      primary_neural_summary=primary, alpha=alpha,
+                      save_dir=args.save_dir))
+    return dict(labels=labels, behavior=behavior, across=across,
+                trialwise=trialwise, trial_df=trial_df)

--- a/dcc_scripts/stats/stability_flexibility_timing_dcc.py
+++ b/dcc_scripts/stats/stability_flexibility_timing_dcc.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python
+"""
+DCC core for A5 — relative onset of stability vs. flexibility information
+(`docs/stability_flexibility_guide.md` §5).
+
+Answers a *sequence* question the conjunction (A2) and cross-decoding (A4) layers
+are silent on: does the **LWPC** (congruency x incongruent-proportion, stability)
+interaction arise EARLIER in the trial than the **LWPS** (switchType x
+switch-proportion, flexibility) interaction, or later?
+
+Pipeline:
+  1. Assemble the long-format single-trial table with `effect_measure='cluster'`,
+     so `hg` holds each trial's HG TIME COURSE over the window rather than the
+     window mean (`assemble_long_df`, reused from the A1/A2 job), plus the window
+     time axis the courses live on (`window_times`).
+  2. `sft.interaction_time_course` for each process: the equal-cell-weight
+     difference-of-differences of the four (cond, mod) cell means per time bin,
+     combined across electrodes. Equal cell weighting keeps the estimate
+     orthogonal to both main effects, so the ~75/25 proportion imbalance cannot
+     leak a main effect in as a fake interaction.
+  3. `sft.onset_50pct_peak` (onset) and `sft.peak_latency` (shape cross-check) on
+     each trace. Normalizing to each effect's OWN peak is what defeats the
+     latency-amplitude confound -- a bigger effect crosses any *absolute*
+     threshold sooner, so without it "earlier" would just rename "larger".
+  4. `sft.jackknife_onset_difference`: onsets read off SMOOTH leave-one-subject-out
+     grand averages, jackknife SE, and the Ulrich-Miller `(N-1)`-corrected paired
+     t on the LWPC - LWPS difference. That signed difference with its CI is the
+     headline.
+  5. Figures: the two interaction time courses with their onset/peak markers, the
+     leave-one-out onset pairs, and the distribution of leave-one-out differences.
+
+Before anything else the job runs `sft._assert_amplitude_invariance` -- the
+latency-amplitude guard as a live assertion (scaling a waveform by k must not move
+its 50%-of-peak onset). A failure there invalidates every onset the job would go
+on to report, so it is checked first and recorded in the summary.
+
+On the SYNTHETIC path `sft._synthetic_timecourse_df` plants a known onset ordering
+(stability rising before flexibility by default), so the whole path is validated
+against ground truth in seconds with no data on disk. Set `SYNTHETIC_STAB_ONSET` >
+`SYNTHETIC_FLEX_ONSET` to plant the reverse ordering and confirm the sign of the
+reported difference flips -- the method reads the order you planted rather than a
+fixed prejudice.
+
+Driven by `run_stability_flexibility_timing_dcc.py` (wrapped by
+`sbatch_stability_flexibility_timing_dcc.sh`). Not run directly on the cluster;
+call `main(args)` with a populated argument namespace.
+"""
+
+import warnings
+warnings.simplefilter(action='ignore', category=FutureWarning)
+
+import sys
+import os
+import json
+
+# ---------------------------------------------------------------------------
+# PATH SETUP (mirrors the other dcc_scripts entrypoints)
+# ---------------------------------------------------------------------------
+try:
+    current_file_path = os.path.abspath(__file__)
+    current_script_dir = os.path.dirname(current_file_path)
+except NameError:
+    current_script_dir = os.getcwd()
+
+project_root = os.path.abspath(os.path.join(current_script_dir, '..', '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+if os.path.exists("/hpc/home"):
+    USER = os.environ.get('USER')
+    sys.path.append(f"/hpc/home/{USER}/coganlab/{USER}/GlobalLocal/IEEG_Pipelines/")
+
+import numpy as np
+import pandas as pd
+
+import matplotlib
+matplotlib.use('Agg')          # headless / cluster
+import matplotlib.pyplot as plt
+
+from src.analysis.stats import stability_flexibility_timing as sft
+
+# NOTE: `general_utils` and the sibling DCC core pull in the mne / ieeg stack at
+# import time, and the long-format assembly they provide is only reachable on the
+# real-data path. They are therefore imported lazily inside `main` so the
+# `DATA_SOURCE=synthetic` dry run validates this job's own logic anywhere the
+# analysis modules import — including a laptop with no cluster environment.
+
+# A5 is only defined for the 2x2 LWPC/LWPS interactions, and needs time courses.
+CONTRAST_MODE = 'proportion'
+EFFECT_MEASURE = 'cluster'
+
+
+# ---------------------------------------------------------------------------
+# the time axis the windowed courses live on
+# ---------------------------------------------------------------------------
+def window_times(subjects_epochs, tmin, tmax):
+    """The [tmin, tmax] window's time axis, verified identical across subjects.
+
+    `assemble_long_df(..., effect_measure='cluster')` stores each trial's windowed
+    HG course but not the axis it was cut on, and A5 reports onsets in SECONDS, so
+    we recover it here from the same `_window_indices` slice. Subjects whose window
+    has a different length (or a different axis) can't be grand-averaged bin-by-bin
+    at all, so that is a hard error rather than a silent truncation.
+    """
+    from dcc_scripts.stats.stability_flexibility_segregation_dcc import _window_indices
+
+    axes = {}
+    for sub, epochs in subjects_epochs.items():
+        t = np.asarray(epochs.times, float)
+        s_idx, e_idx = _window_indices(t, tmin, tmax)
+        axes[sub] = t[s_idx:e_idx]
+
+    lengths = {sub: len(a) for sub, a in axes.items()}
+    if len(set(lengths.values())) > 1:
+        raise RuntimeError(
+            "subjects disagree on the number of samples in the analysis window "
+            f"[{tmin}, {tmax}]s: {lengths}. A5 grand-averages the interaction "
+            "bin-by-bin across electrodes, so every subject must share one time "
+            "axis -- resample/crop the epochs to a common axis first.")
+
+    ref_sub, ref = next(iter(axes.items()))
+    for sub, a in axes.items():
+        if not np.allclose(a, ref, atol=1e-9):
+            raise RuntimeError(
+                f"subject {sub!r} has the same number of window samples as "
+                f"{ref_sub!r} but a different time axis (max deviation "
+                f"{np.max(np.abs(a - ref)):.6g}s). Resample to a common axis first.")
+    return ref
+
+
+# ---------------------------------------------------------------------------
+# serialization
+# ---------------------------------------------------------------------------
+def _json_safe(o):
+    if isinstance(o, (np.floating, np.integer)):
+        return o.item()
+    if isinstance(o, np.ndarray):
+        return o.tolist()
+    if isinstance(o, (list, tuple)):
+        return [_json_safe(v) for v in o]
+    if isinstance(o, dict):
+        return {k: _json_safe(v) for k, v in o.items()}
+    return o
+
+
+def save_results(times, traces, onsets, jk, save_dir):
+    os.makedirs(save_dir, exist_ok=True)
+
+    # the interaction time courses themselves (the raw material of every onset)
+    pd.DataFrame(dict(time=times,
+                      lwpc=traces['stability'],
+                      lwps=traces['flexibility'])).to_csv(
+        os.path.join(save_dir, 'interaction_time_courses.csv'), index=False)
+
+    # the N leave-one-out onset pairs behind the jackknife SE
+    pd.DataFrame(dict(left_out_index=np.arange(len(jk['onset_lwpc_loo'])),
+                      onset_lwpc=jk['onset_lwpc_loo'],
+                      onset_lwps=jk['onset_lwps_loo'],
+                      diff=jk['diffs'])).to_csv(
+        os.path.join(save_dir, 'jackknife_leave_one_out.csv'), index=False)
+
+    # the headline test (arrays stripped -- they are in the CSVs above)
+    payload = {k: v for k, v in jk.items()
+               if k not in ('onset_lwpc_loo', 'onset_lwps_loo', 'diffs')}
+    payload.update(onsets)
+    with open(os.path.join(save_dir, 'onset_difference.json'), 'w') as f:
+        json.dump(_json_safe(payload), f, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# figures
+# ---------------------------------------------------------------------------
+def make_plots(times, traces, onsets, jk, save_dir, statistic='mean'):
+    ylab = ("interaction d-o-d (grand mean)" if statistic == 'mean'
+            else "interaction d-o-d (t across electrodes)")
+    fig, ax = plt.subplots(1, 3, figsize=(17, 4.2))
+
+    # (1) the two interaction time courses with onset (50%-of-peak) + peak markers
+    for key, name, colour, o_k, p_k in (
+            ('stability', 'LWPC (stability)', '#2c7fb8', 'onset_lwpc', 'peak_lwpc'),
+            ('flexibility', 'LWPS (flexibility)', '#d95f0e', 'onset_lwps', 'peak_lwps')):
+        trace = np.asarray(traces[key], float)
+        ax[0].plot(times, trace, color=colour, lw=2, label=name)
+        onset, peak_t = onsets[o_k], onsets[p_k]
+        finite = trace[np.isfinite(trace)]
+        if finite.size:
+            # mark the threshold in the trace's own (auto-resolved) direction
+            peak = finite[np.argmax(np.abs(finite))]
+            ax[0].axhline(0.5 * peak, color=colour, ls=':', lw=1)
+            if np.isfinite(onset):
+                ax[0].plot(onset, 0.5 * peak, 'o', color=colour, ms=9)
+            if np.isfinite(peak_t):
+                ax[0].axvline(peak_t, color=colour, ls='--', lw=0.8, alpha=0.6)
+    ax[0].axhline(0, color='k', lw=0.5)
+    ax[0].set(title="A5 · interaction time courses\n(dot = 50%-of-peak onset, "
+                    "dashed = peak latency)",
+              xlabel="time (s)", ylabel=ylab)
+    ax[0].legend(fontsize=8)
+
+    # (2) the leave-one-out onset pairs -- why the jackknife is stable
+    x = np.arange(len(jk['onset_lwpc_loo']))
+    ax[1].plot(x, jk['onset_lwpc_loo'], 'o-', color='#2c7fb8', label='LWPC onset')
+    ax[1].plot(x, jk['onset_lwps_loo'], 'o-', color='#d95f0e', label='LWPS onset')
+    ax[1].set(title="A5 · leave-one-subject-out onsets",
+              xlabel="index of the left-out subject", ylabel="onset (s)")
+    ax[1].legend(fontsize=8)
+
+    # (3) the leave-one-out differences + the CI on the jackknife estimate
+    d = np.asarray(jk['diffs'], float)
+    d = d[np.isfinite(d)]
+    if d.size:
+        ax[2].hist(d, bins=max(5, min(20, d.size)), color="#bbb")
+    ax[2].axvline(jk['diff'], color="#d7191c", lw=2,
+                  label=f"mean diff = {jk['diff']:+.3f} s")
+    ax[2].axvspan(jk['ci'][0], jk['ci'][1], color="#d7191c", alpha=0.12,
+                  label=f"95% CI [{jk['ci'][0]:+.3f}, {jk['ci'][1]:+.3f}]")
+    ax[2].axvline(0, color='k', lw=0.8, ls=':')
+    ax[2].set(title=f"A5 · onset difference (LWPC - LWPS)\n"
+                    f"t_corrected = {jk['t_corrected']:.2f}  p = {jk['p']:.4g}  "
+                    f"df = {jk['df']}",
+              xlabel="leave-one-out onset difference (s)", ylabel="# leave-outs")
+    ax[2].legend(fontsize=8)
+
+    fig.tight_layout()
+    fig.savefig(os.path.join(save_dir, 'timing_summary.png'), dpi=140,
+                bbox_inches='tight')
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# text summary
+# ---------------------------------------------------------------------------
+def write_summary(times, onsets, jk, save_dir, meta, guard_onset, alpha=0.05):
+    lead = ("stability (LWPC) leads" if jk['diff'] < 0 else
+            "flexibility (LWPS) leads" if jk['diff'] > 0 else "no ordering")
+    ci_excludes_zero = (jk['ci'][0] > 0) or (jk['ci'][1] < 0)
+    verdict = ("RELIABLE ordering" if (jk['p'] < alpha and ci_excludes_zero)
+               else "ordering NOT reliable")
+
+    # Onset and peak latency should tell the SAME story before an ordering is
+    # claimed -- unless an effect is still at its ceiling when the window ends, in
+    # which case its "peak" is just the last bin and carries no latency
+    # information. Distinguish those two cases rather than crying disagreement.
+    times = np.asarray(times, float)
+    dt = float(np.median(np.diff(times))) if times.size > 1 else 0.0
+    edge = times[-1] - dt
+    at_edge = [k for k, v in (('LWPC', onsets['peak_lwpc']),
+                              ('LWPS', onsets['peak_lwps']))
+               if np.isfinite(v) and v >= edge]
+    onset_sign = np.sign(jk['diff_full'])
+    peak_sign = np.sign(jk['peak_diff'])
+    agree = bool(np.isfinite(onset_sign) and np.isfinite(peak_sign)
+                 and onset_sign == peak_sign and onset_sign != 0)
+    peak_check = ("UNINFORMATIVE (peak at the window edge for "
+                  + "/".join(at_edge) + " — the effect is still rising/plateaued "
+                  "at WINDOW_TMAX)") if at_edge else str(agree)
+
+    lines = [
+        "=" * 70,
+        "STABILITY vs FLEXIBILITY — A5 TIMING (relative onset)",
+        "=" * 70,
+    ]
+    for k, v in meta.items():
+        lines.append(f"{k:>22}: {v}")
+    lines += [
+        "-" * 70,
+        f"latency-amplitude guard: PASSED "
+        f"(50%-of-peak onset invariant under k-scaling; onset={guard_onset:.4f}s)",
+        "-" * 70,
+        "FULL-SAMPLE LATENCIES (descriptive):",
+        f"      LWPC (stability)   onset = {onsets['onset_lwpc']:.4f} s   "
+        f"peak = {onsets['peak_lwpc']:.4f} s",
+        f"      LWPS (flexibility) onset = {onsets['onset_lwps']:.4f} s   "
+        f"peak = {onsets['peak_lwps']:.4f} s",
+        f"      onset difference (LWPC - LWPS) = {jk['diff_full']:+.4f} s",
+        f"      peak  difference (LWPC - LWPS) = {jk['peak_diff']:+.4f} s",
+        f"      onset and peak agree on the ordering: {peak_check}",
+        "-" * 70,
+        f"JACKKNIFE (Ulrich-Miller, N = {jk['n_subjects']} subjects):",
+        f"      mean leave-one-out difference = {jk['diff']:+.4f} s",
+        f"      jackknife SE                  = {jk['se']:.4f} s",
+        f"      95% CI                        = [{jk['ci'][0]:+.4f}, {jk['ci'][1]:+.4f}] s",
+        f"      t_raw = {jk['t_raw']:.3f}  ->  t_corrected = t_raw/(N-1) = "
+        f"{jk['t_corrected']:.3f}   (df = {jk['df']})",
+        f"      p = {jk['p']:.4g}   ->  {verdict}   [{lead}]",
+        "=" * 70,
+        "Reading: the SIGN of the onset difference says which process's information",
+        "arises first (negative = stability leads); the CI / (N-1)-corrected t say",
+        "whether that ordering is reliable. Onset is measured at 50% of each",
+        "effect's OWN peak, so a pure amplitude difference cannot masquerade as an",
+        "onset difference. Claim an ordering only when onset AND peak latency agree.",
+    ]
+    if at_edge:
+        lines.append("WARNING: the peak-latency cross-check is uninformative — "
+                     + "/".join(at_edge) + " peaks at the window")
+        lines.append("         edge, so its 'peak' is just the last bin. Widen "
+                     "WINDOW_TMAX until both")
+        lines.append("         effects turn over before claiming an ordering.")
+    elif not agree:
+        lines.append("WARNING: onset and peak latency disagree on the ordering — the")
+        lines.append("         waveform shapes differ (plateau vs transient); do not")
+        lines.append("         claim an ordering on the onset alone.")
+    txt = "\n".join(str(x) for x in lines)
+    with open(os.path.join(save_dir, 'summary.txt'), 'w') as f:
+        f.write(txt + "\n")
+    print(txt)
+
+
+# ---------------------------------------------------------------------------
+# orchestrator
+# ---------------------------------------------------------------------------
+def main(args):
+    alpha = getattr(args, 'alpha', 0.05)
+    statistic = getattr(args, 'statistic', 'mean')
+
+    print(f"contrast_mode: {CONTRAST_MODE} | effect_measure: {EFFECT_MEASURE} | "
+          f"statistic: {statistic}")
+    os.makedirs(args.save_dir, exist_ok=True)
+
+    # 0. the latency-amplitude guard, as a live assertion --------------------------
+    # If a k-scaled waveform moved its 50%-of-peak onset, every onset below would be
+    # confounded with amplitude, so this runs BEFORE any data is touched.
+    guard_onset = sft._assert_amplitude_invariance(k=3.7)
+    print(f"latency-amplitude guard passed (onset invariant under k-scaling: "
+          f"{guard_onset:.4f}s)")
+
+    # 1. long-format TIME-COURSE table + the window time axis ----------------------
+    if args.data_source == 'synthetic':
+        print("DATA SOURCE: synthetic (pipeline / path validation)")
+        df, times = sft._synthetic_timecourse_df(
+            n_subj=getattr(args, 'synthetic_n_subj', 12),
+            seed=getattr(args, 'seed', 0),
+            stab_onset=getattr(args, 'synthetic_stab_onset', 0.20),
+            flex_onset=getattr(args, 'synthetic_flex_onset', 0.40))
+        print(f"synthetic df: {len(df)} rows | {df.subject.nunique()} subjects | "
+              f"{df.electrode.nunique()} electrodes | {len(times)} time bins")
+        print(f"planted onsets: LWPC={getattr(args, 'synthetic_stab_onset', 0.20)}s "
+              f"LWPS={getattr(args, 'synthetic_flex_onset', 0.40)}s")
+    else:
+        print("DATA SOURCE: real epoched data")
+        from src.analysis.utils.general_utils import (
+            resolve_lab_root, resolve_electrodes_to_keep,
+            load_HG_ev1_rescaled_per_subject)
+        # reuse the SAME long-format assembly as the sibling A1/A2/A3 jobs
+        from dcc_scripts.stats.stability_flexibility_segregation_dcc import assemble_long_df
+
+        LAB_root = resolve_lab_root(args.LAB_root)
+        print(f"LAB_root: {LAB_root}")
+        subjects_epochs = load_HG_ev1_rescaled_per_subject(
+            subjects=args.subjects, epochs_root_file=args.epochs_root_file,
+            task=args.task, LAB_root=LAB_root, acc_trials_only=args.acc_trials_only)
+        keep = resolve_electrodes_to_keep(args, LAB_root)
+        times = window_times(subjects_epochs, args.window_tmin, args.window_tmax)
+        df = assemble_long_df(subjects_epochs, args.window_tmin, args.window_tmax,
+                              electrodes_to_keep=keep, effect_measure=EFFECT_MEASURE)
+        print(f"assembled df: {len(df)} rows | {df.subject.nunique()} subjects | "
+              f"{df.electrode.nunique()} electrodes | {len(times)} time bins "
+              f"({times[0]:.3f} -> {times[-1]:.3f}s)")
+        for col in ('incongruent_proportion', 'switch_proportion'):
+            if col not in df.columns or df[col].isna().all():
+                raise RuntimeError(
+                    f"df is missing usable '{col}' — A5 measures the onset of the "
+                    "LWPC/LWPS 2x2 INTERACTIONS, which need the block-proportion "
+                    "columns.")
+        # The time-course table is far too large to serialize as CSV (one array per
+        # trial per electrode); the per-bin interaction traces below are the
+        # reusable artifact.
+
+    n_subj = int(df['subject'].nunique())
+    if n_subj < 3:
+        raise RuntimeError(f"the jackknife needs >= 3 subjects; the assembled "
+                           f"table has {n_subj}")
+
+    # 2. interaction magnitude over time, per process ------------------------------
+    print("A5: per-bin equal-cell-weight difference-of-differences, per process")
+    traces = {}
+    for key in ('stability', 'flexibility'):
+        _, traces[key] = sft.interaction_time_course(
+            df, key, contrast_mode=CONTRAST_MODE, times=times, statistic=statistic)
+
+    # 3. onset (50%-of-peak) + peak latency on the full sample ---------------------
+    onsets = dict(
+        onset_lwpc=sft.onset_50pct_peak(times, traces['stability']),
+        onset_lwps=sft.onset_50pct_peak(times, traces['flexibility']),
+        peak_lwpc=sft.peak_latency(times, traces['stability']),
+        peak_lwps=sft.peak_latency(times, traces['flexibility']))
+    print(f"      LWPC onset={onsets['onset_lwpc']:.4f}s peak={onsets['peak_lwpc']:.4f}s | "
+          f"LWPS onset={onsets['onset_lwps']:.4f}s peak={onsets['peak_lwps']:.4f}s")
+
+    # 4. jackknifed onset-difference test ------------------------------------------
+    print(f"A5: Ulrich-Miller jackknife over {n_subj} leave-one-subject-out "
+          f"grand averages")
+    jk = sft.jackknife_onset_difference(
+        df, contrast_mode=CONTRAST_MODE, times=times, statistic=statistic)
+
+    # 5. persist + plot + summarize ------------------------------------------------
+    save_results(times, traces, onsets, jk, args.save_dir)
+    make_plots(times, traces, onsets, jk, args.save_dir, statistic=statistic)
+    write_summary(times, onsets, jk, args.save_dir, guard_onset=guard_onset, alpha=alpha,
+                  meta=dict(
+                      data_source=args.data_source, task=args.task,
+                      epochs_root_file=getattr(args, 'epochs_root_file', None),
+                      n_subjects=n_subj,
+                      n_electrodes=int(df['electrode'].nunique()),
+                      window=f"[{times[0]:.3f}, {times[-1]:.3f}]s "
+                             f"({len(times)} bins)",
+                      contrast_mode=CONTRAST_MODE, effect_measure=EFFECT_MEASURE,
+                      statistic=statistic, alpha=alpha, save_dir=args.save_dir))
+    return dict(times=times, traces=traces, onsets=onsets, jackknife=jk)

--- a/dcc_scripts/stats/submit_stability_flexibility_brain_behavior_dcc.sh
+++ b/dcc_scripts/stats/submit_stability_flexibility_brain_behavior_dcc.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Submit A6 — brain-behavior correlation: does the A1 neural selectivity predict
+# the actual behavioral control adjustment? Across subjects (underpowered) and
+# within subject on single trials (preferred), each with its cross-pairing
+# specificity control.
+#
+# Usage:
+#   bash submit_stability_flexibility_brain_behavior_dcc.sh                       # real data
+#   DATA_SOURCE=synthetic bash submit_stability_flexibility_brain_behavior_dcc.sh # dry-run
+#
+# Falsification dry-run — destroy the specificity (each neural group drives BOTH
+# adjustments equally) and confirm `specificity_ok` stops holding:
+#   DATA_SOURCE=synthetic SYNTHETIC_CROSS_FRAC=1.0 \
+#       bash submit_stability_flexibility_brain_behavior_dcc.sh
+
+# ---------------------------------------------------------------------------
+# Epochs file (high-gamma, rescaled). Match one you actually have on disk.
+# ---------------------------------------------------------------------------
+EPOCHS_ROOT_FILE="Stimulus_-1.0to1.5sec_0.5sec_within-1.0-0.0sec_base_decFactor_8_outliers_10_drop_thresh_perc_5.0_70.0-150.0_Hz_padLength_1.5s_filterbank_hilbert_stat_func_ttest_ind_equal_var_False_nan_policy_omit"
+
+# ---------------------------------------------------------------------------
+# Raw trial-level behavior. Defaults to the repo-root combinedData.csv; point it
+# at the Box copy on the cluster if that is where yours lives.
+# ---------------------------------------------------------------------------
+BEHAVIOR_CSV=${BEHAVIOR_CSV:-"$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/combinedData.csv"}
+BEHAVIOR_RT_COL=${BEHAVIOR_RT_COL:-RT}
+
+# ---------------------------------------------------------------------------
+# Analysis window (seconds relative to stimulus onset) and electrode set.
+# ---------------------------------------------------------------------------
+WINDOW_TMIN=${WINDOW_TMIN:-0.0}
+WINDOW_TMAX=${WINDOW_TMAX:-0.5}
+ELECTRODES=${ELECTRODES:-all}       # 'all' or 'sig'
+
+# Data source: 'real' loads epoched data + the behavioral CSV; 'synthetic' plants
+# a matched coupling stronger than its cross control and validates the whole path.
+DATA_SOURCE=${DATA_SOURCE:-real}
+SYNTHETIC_N_SUBJ=${SYNTHETIC_N_SUBJ:-16}
+SYNTHETIC_ACROSS_BETA=${SYNTHETIC_ACROSS_BETA:-1.2}
+SYNTHETIC_WITHIN_BETA=${SYNTHETIC_WITHIN_BETA:-0.6}
+SYNTHETIC_CROSS_FRAC=${SYNTHETIC_CROSS_FRAC:-0.25}
+
+# A1 electrode definition + A6 hyperparameters.
+ALPHA=${ALPHA:-0.05}
+# which per-subject neural summary headlines the across-subject level:
+# 'count' | 'frac' | 'effect' (all three are computed; this picks the primary).
+NEURAL_SUMMARY=${NEURAL_SUMMARY:-count}
+# the within-subject single-trial level needs per-trial RT in the epochs metadata;
+# set to 0 for the across-subject level only.
+RUN_TRIALWISE=${RUN_TRIALWISE:-1}
+SEED=${SEED:-0}
+
+mkdir -p out
+
+echo "Submitting stability/flexibility A6 brain-behavior (source=$DATA_SOURCE)"
+sbatch --job-name="sf_brainbehav_${DATA_SOURCE}" \
+    --export=ALL,EPOCHS_ROOT_FILE="$EPOCHS_ROOT_FILE",BEHAVIOR_CSV="$BEHAVIOR_CSV",BEHAVIOR_RT_COL="$BEHAVIOR_RT_COL",WINDOW_TMIN="$WINDOW_TMIN",WINDOW_TMAX="$WINDOW_TMAX",ELECTRODES="$ELECTRODES",DATA_SOURCE="$DATA_SOURCE",SYNTHETIC_N_SUBJ="$SYNTHETIC_N_SUBJ",SYNTHETIC_ACROSS_BETA="$SYNTHETIC_ACROSS_BETA",SYNTHETIC_WITHIN_BETA="$SYNTHETIC_WITHIN_BETA",SYNTHETIC_CROSS_FRAC="$SYNTHETIC_CROSS_FRAC",ALPHA="$ALPHA",NEURAL_SUMMARY="$NEURAL_SUMMARY",RUN_TRIALWISE="$RUN_TRIALWISE",SEED="$SEED" \
+    sbatch_stability_flexibility_brain_behavior_dcc.sh

--- a/dcc_scripts/stats/submit_stability_flexibility_timing_dcc.sh
+++ b/dcc_scripts/stats/submit_stability_flexibility_timing_dcc.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Submit A5 — relative onset of stability (LWPC) vs. flexibility (LWPS):
+# per-bin interaction time courses, 50%-of-peak onsets, and the Ulrich-Miller
+# jackknifed onset-difference test.
+#
+# Usage:
+#   bash submit_stability_flexibility_timing_dcc.sh                       # real data
+#   DATA_SOURCE=synthetic bash submit_stability_flexibility_timing_dcc.sh # dry-run
+#
+# Falsification dry-run — plant the REVERSE ordering and confirm the reported
+# sign flips (the method reads the order you planted, not a fixed prejudice):
+#   DATA_SOURCE=synthetic SYNTHETIC_STAB_ONSET=0.40 SYNTHETIC_FLEX_ONSET=0.20 \
+#       bash submit_stability_flexibility_timing_dcc.sh
+
+# ---------------------------------------------------------------------------
+# Epochs file (high-gamma, rescaled). Match one you actually have on disk.
+# ---------------------------------------------------------------------------
+EPOCHS_ROOT_FILE="Stimulus_-1.0to1.5sec_0.5sec_within-1.0-0.0sec_base_decFactor_8_outliers_10_drop_thresh_perc_5.0_70.0-150.0_Hz_padLength_1.5s_filterbank_hilbert_stat_func_ttest_ind_equal_var_False_nan_policy_omit"
+
+# ---------------------------------------------------------------------------
+# Analysis window (seconds relative to stimulus onset) and electrode set.
+# A5 reads a RISING FLANK, so this window is wider than the A1/A2 window-mean
+# default: it must include the pre-onset baseline and enough post-stimulus time
+# for BOTH interactions to reach their peak (the 50%-of-peak threshold is
+# meaningless if an effect is still climbing at WINDOW_TMAX).
+# ---------------------------------------------------------------------------
+WINDOW_TMIN=${WINDOW_TMIN:--0.2}
+WINDOW_TMAX=${WINDOW_TMAX:-0.8}
+ELECTRODES=${ELECTRODES:-all}       # 'all' or 'sig'
+
+# Data source: 'real' loads epoched HG time courses; 'synthetic' validates the
+# whole path against a planted onset ordering.
+DATA_SOURCE=${DATA_SOURCE:-real}
+SYNTHETIC_N_SUBJ=${SYNTHETIC_N_SUBJ:-12}
+SYNTHETIC_STAB_ONSET=${SYNTHETIC_STAB_ONSET:-0.20}
+SYNTHETIC_FLEX_ONSET=${SYNTHETIC_FLEX_ONSET:-0.40}
+
+# A5 hyperparameters.
+# STATISTIC: 'mean' = grand-average d-o-d(t); 't' = t across electrodes (noise-
+# normalized, often a cleaner flank). Report both if they disagree.
+STATISTIC=${STATISTIC:-mean}
+ALPHA=${ALPHA:-0.05}
+SEED=${SEED:-0}
+
+mkdir -p out
+
+echo "Submitting stability/flexibility A5 timing (source=$DATA_SOURCE)"
+sbatch --job-name="sf_timing_${DATA_SOURCE}" \
+    --export=ALL,EPOCHS_ROOT_FILE="$EPOCHS_ROOT_FILE",WINDOW_TMIN="$WINDOW_TMIN",WINDOW_TMAX="$WINDOW_TMAX",ELECTRODES="$ELECTRODES",DATA_SOURCE="$DATA_SOURCE",SYNTHETIC_N_SUBJ="$SYNTHETIC_N_SUBJ",SYNTHETIC_STAB_ONSET="$SYNTHETIC_STAB_ONSET",SYNTHETIC_FLEX_ONSET="$SYNTHETIC_FLEX_ONSET",STATISTIC="$STATISTIC",ALPHA="$ALPHA",SEED="$SEED" \
+    sbatch_stability_flexibility_timing_dcc.sh

--- a/docs/analysis_paths.md
+++ b/docs/analysis_paths.md
@@ -113,7 +113,8 @@ dcc_scripts/      # Cluster launchers (what you actually run)
 ├── power/        # run_power_traces_dcc.py, power_traces_dcc.py, sbatch/submit *.sh
 ├── decoding/     # run_decoding_dcc.py, decoding_dcc.py, sbatch/submit *.sh
 │                 # + stability_flexibility_cross_decoding (A4) + def-split launcher (§13)
-└── stats/        # A1/A2 (anova_conjunction, segregation) + A3 (anatomy) launchers (§12)
+└── stats/        # A1/A2 (anova_conjunction, segregation) + A3 (anatomy)
+                  # + A5 (timing) + A6 (brain_behavior) launchers (§12)
 ```
 
 ---
@@ -527,7 +528,7 @@ list-wide proportion-switch adjustment, i.e. reactive/task-switching control)
 carried by the **same** neural machinery or by **distinct** machinery? The
 battery attacks that one question from six complementary angles. Each angle is a
 numbered assignment (`A1`–`A6`) with a production module, a **tutorial
-notebook**, and — for A1–A4 — a **DCC launcher**.
+notebook**, and a **DCC launcher**.
 
 **The governing document** (read this for the *why*, the how, and the run order):
 - **`docs/stability_flexibility_guide.md`** — the single merged guide: scientific
@@ -555,8 +556,8 @@ whole battery end to end.
 | **A2** | §2 | Do S and F co-occur on the same electrodes more/less than chance? | `stats/stability_flexibility_segregation.py` (`cmh_conjunction`, permutation null, threshold sweep, `subject_clustered_corr`) | same as A1 | same as A1 (+ `submit_stability_flexibility_segregation_dcc.sh` for the continuous/CMH-only run) |
 | **A3** | §3 | Are the distinct subpopulations in different **places** (conditioned on coverage)? | `stats/stability_flexibility_anatomy.py` | `stats/stability_flexibility_anatomy_tutorial.ipynb` | `dcc_scripts/stats/submit_stability_flexibility_anatomy_dcc.sh` |
 | **A4** | §4 | One **shared code** or two **orthogonal codes** on the `both` electrodes? | `decoding/cross_decoding.py` | `decoding/cross_decoding_tutorial.ipynb` | `dcc_scripts/decoding/submit_stability_flexibility_cross_decoding_dcc.sh` |
-| **A5** | §5 | Does stability information arise **earlier** than flexibility (or vice versa)? | `stats/stability_flexibility_timing.py` | `stats/stability_flexibility_a5_a6_tutorial.ipynb` | none — notebook + module smoke test |
-| **A6** | §6 | Does the neural selectivity predict the actual **behavioral** control adjustment? | `stats/stability_flexibility_brain_behavior.py` | `stats/stability_flexibility_a5_a6_tutorial.ipynb` | none — notebook + module smoke test |
+| **A5** | §5 | Does stability information arise **earlier** than flexibility (or vice versa)? | `stats/stability_flexibility_timing.py` | `stats/stability_flexibility_a5_a6_tutorial.ipynb` | `dcc_scripts/stats/submit_stability_flexibility_timing_dcc.sh` |
+| **A6** | §6 | Does the neural selectivity predict the actual **behavioral** control adjustment? | `stats/stability_flexibility_brain_behavior.py` | `stats/stability_flexibility_a5_a6_tutorial.ipynb` | `dcc_scripts/stats/submit_stability_flexibility_brain_behavior_dcc.sh` |
 
 **Consumes:** the same saved HG epochs as power/decoding, assembled into a
 **long single-trial table** (`subject | electrode | hg | congruency | switchType
@@ -693,11 +694,23 @@ the **latency–amplitude confound** — a bigger effect crosses any *absolute*
 threshold sooner, so without this "earlier" would just mean "larger" (baked into a
 unit test: `stab(t) = k·flex(t)` ⇒ equal onsets).
 
-**Run it** (no DCC launcher — notebook + module smoke test):
+**Run on DCC** (from `dcc_scripts/stats`):
 ```bash
-python src/analysis/stats/stability_flexibility_timing.py   # synthetic smoke test
+DATA_SOURCE=synthetic bash submit_stability_flexibility_timing_dcc.sh   # dry run
+# falsification — plant the REVERSE ordering; the reported sign must flip:
+DATA_SOURCE=synthetic SYNTHETIC_STAB_ONSET=0.40 SYNTHETIC_FLEX_ONSET=0.20 \
+    bash submit_stability_flexibility_timing_dcc.sh
+bash submit_stability_flexibility_timing_dcc.sh                        # real (set EPOCHS_ROOT_FILE first)
 ```
-then walk `src/analysis/stats/stability_flexibility_a5_a6_tutorial.ipynb`.
+Note the launcher's window defaults to `[-0.2, 0.8]s` rather than the A1/A2
+`[0.0, 0.5]s`: A5 reads a **rising flank**, so the window must contain the
+baseline and enough post-stimulus time for both effects to turn over — a
+50 %-of-peak threshold is meaningless while an effect is still climbing at
+`WINDOW_TMAX` (the job warns when that happens).
+
+For a no-cluster check: `python src/analysis/stats/stability_flexibility_timing.py`
+(module smoke test), then walk
+`src/analysis/stats/stability_flexibility_a5_a6_tutorial.ipynb`.
 
 **Interpret the output.** The signed **onset difference with a CI** (from
 `jackknife_onset_difference`) is the headline: its sign says which process's
@@ -717,11 +730,28 @@ adjustment), via a mixed model with a subject random effect? Behavioral effects
 come from the same design as `stats/erin_linear_mixed_effects_model.py` /
 `combinedData.csv`.
 
-**Run it** (no DCC launcher — notebook + module smoke test):
+**Run on DCC** (from `dcc_scripts/stats`):
 ```bash
-python src/analysis/stats/stability_flexibility_brain_behavior.py   # synthetic smoke test
+DATA_SOURCE=synthetic bash submit_stability_flexibility_brain_behavior_dcc.sh   # dry run
+# falsification — each neural group drives BOTH adjustments equally, so
+# `specificity_ok` must stop holding:
+DATA_SOURCE=synthetic SYNTHETIC_CROSS_FRAC=1.0 \
+    bash submit_stability_flexibility_brain_behavior_dcc.sh
+bash submit_stability_flexibility_brain_behavior_dcc.sh                        # real (set EPOCHS_ROOT_FILE, BEHAVIOR_CSV)
 ```
-then walk `src/analysis/stats/stability_flexibility_a5_a6_tutorial.ipynb`.
+`trialwise_brain_behavior` takes the per-trial behavioral adjustment columns as
+*input* — the operationalization is a design choice, so the launcher makes it
+explicit: `adj_congruency(t) = w(t) · (RT_t − that subject's mean RT)`, where
+`w(t)` is the trial's cell weight in the LWPC difference-of-differences (`+1` on
+the (i, high-incongruent) / (c, low-incongruent) diagonal, `−1` on the other).
+A subject's mean `adj_congruency` is therefore their behavioral LWPC / 4, and RT
+and the group HG are both **centered within subject** so the mixed-model slope is
+a purely within-subject quantity. See `dcc_scripts/stats/README.md` (A6) for the
+full statement.
+
+For a no-cluster check:
+`python src/analysis/stats/stability_flexibility_brain_behavior.py` (module smoke
+test), then walk `src/analysis/stats/stability_flexibility_a5_a6_tutorial.ipynb`.
 
 **Interpret the output.** The **matched** pairing (LWPC group ↔ congruency-sequence
 adjustment; LWPS group ↔ switch adjustment) should be **stronger than the cross**

--- a/docs/stability_flexibility_guide.md
+++ b/docs/stability_flexibility_guide.md
@@ -851,7 +851,33 @@ FRAC_DEF=0.6 SEED=1 ALPHA=0.05 STRATA=congruency,switchType,blockType \
     bash submit_decoding_with_electrode_definition_split_dcc.sh
 ```
 
-**A5 / A6 — timing + brain–behavior** (no DCC launcher; notebook + smoke test):
+**A5 — timing** (from `dcc_scripts/stats`):
+```bash
+DATA_SOURCE=synthetic bash submit_stability_flexibility_timing_dcc.sh                    # planted onset ordering
+DATA_SOURCE=synthetic SYNTHETIC_STAB_ONSET=0.40 SYNTHETIC_FLEX_ONSET=0.20 \
+    bash submit_stability_flexibility_timing_dcc.sh                                      # reversed -> sign must flip
+bash submit_stability_flexibility_timing_dcc.sh                                          # real
+```
+The window defaults to `[-0.2, 0.8]s`, wider than the A1/A2 `[0.0, 0.5]s`: A5 reads
+a **rising flank**, so it needs the baseline plus enough post-stimulus time for both
+effects to turn over. `STATISTIC=t` swaps the grand-average d-o-d(t) for a
+noise-normalized t across electrodes (often a cleaner flank).
+
+**A6 — brain–behavior** (from `dcc_scripts/stats`):
+```bash
+DATA_SOURCE=synthetic bash submit_stability_flexibility_brain_behavior_dcc.sh                       # planted matched > cross
+DATA_SOURCE=synthetic SYNTHETIC_CROSS_FRAC=1.0 bash submit_stability_flexibility_brain_behavior_dcc.sh  # specificity destroyed
+bash submit_stability_flexibility_brain_behavior_dcc.sh                                             # real
+```
+Set `BEHAVIOR_CSV` if the raw trial-level behavior is not the repo-root
+`combinedData.csv`; `RUN_TRIALWISE=0` runs the across-subject level only. The
+launcher defines the per-trial adjustment columns `trialwise_brain_behavior` takes
+as input — each trial's signed contribution to its process's difference-of-
+differences (d-o-d cell weight × subject-centered RT) — documented in
+`dcc_scripts/stats/README.md` (A6).
+
+Either module also runs standalone as a synthetic smoke test with no cluster
+environment:
 ```bash
 python src/analysis/stats/stability_flexibility_timing.py          # synthetic smoke test
 python src/analysis/stats/stability_flexibility_brain_behavior.py  # synthetic smoke test


### PR DESCRIPTION
A1-A4 each had a four-file cluster launcher set; A5 and A6 only had the tutorial notebook and the module smoke test. This adds the missing sets, following the A3 anatomy pattern (core / run_ / sbatch_ / submit_).

A5 - stability_flexibility_timing_dcc.py
  Assembles the long table in effect_measure='cluster' mode (per-trial HG
  time courses) plus the window time axis, builds the per-bin equal-cell-
  weight difference-of-differences per process, measures 50%-of-peak onset
  and peak latency, and runs the Ulrich-Miller jackknifed onset-difference
  test. The latency-amplitude guard (_assert_amplitude_invariance) runs
  before any data is touched, since a failure there would invalidate every
  onset the job goes on to report.

  window_times() recovers the axis assemble_long_df does not return and
  hard-errors when subjects disagree on it - bin-by-bin grand-averaging is
  meaningless across mismatched axes. The window defaults to [-0.2, 0.8]s
  rather than the A1/A2 [0.0, 0.5]s because A5 reads a rising flank. The
  summary distinguishes "onset and peak disagree" from "the peak sits at the
  window edge, so the cross-check carries no latency information".

A6 - stability_flexibility_brain_behavior_dcc.py
  Runs the A1 electrode definition, derives per-subject behavioral LWPC/LWPS
  RT magnitudes from the raw trial table, and runs both levels - the
  across-subject correlation for all three neural summaries and the
  within-subject single-trial mixed model - each with its cross-pairing
  specificity control.

  trialwise_brain_behavior takes the per-trial adjustment columns as input
  and deliberately does not define them, so the launcher does:
  adj(t) = w(t) * (RT_t - that subject's mean RT), with w(t) the trial's
  cell weight in the process's difference-of-differences. A subject's mean
  adjustment is therefore their behavioral d-o-d / 4. RT and the group HG
  are centered within subject so the slope stays a within-subject quantity.

Both cores import the mne/ieeg-backed helpers lazily inside the real-data branch, so DATA_SOURCE=synthetic validates the job's own logic without a cluster environment. Both synthetic paths were run, including the falsification variants: reversing the planted onsets flips the reported sign, and SYNTHETIC_CROSS_FRAC=1.0 turns specificity_ok False.

Docs: dcc_scripts/stats/README.md gains A5/A6 sections; the analysis_paths §12 launcher column and the guide's §9 run order now list both.


Claude-Session: https://claude.ai/code/session_019EgUWsqbmxzTgJkGCwWrKP