### PR TITLE
Align the continuous segregation route to a power_traces run, as conf…

### DIFF
--- a/dcc_scripts/stats/run_stability_flexibility_segregation_dcc.py
+++ b/dcc_scripts/stats/run_stability_flexibility_segregation_dcc.py
@@ -58,6 +58,30 @@ if DATA_SOURCE == 'real' and EPOCHS_ROOT_FILE is None:
 WINDOW_TMIN = float(os.environ.get('WINDOW_TMIN', '0.0'))   # seconds post-stimulus
 WINDOW_TMAX = float(os.environ.get('WINDOW_TMAX', '0.5'))
 
+# --- window alignment with a power_traces electrode-definition run -----------
+# When the 2x2 counts come from the cluster-corrected windowed ANOVA
+# (`power_traces_conjunction`), this continuous correlation is the CONFOUND
+# CONTROL for those counts, not a second headline: it is the only route that
+# residualises on responsiveness and estimates the two sensitivities on disjoint
+# trial halves, which are the two things the count test cannot control.
+#
+# It stays an independent estimate -- different estimator, different temporal
+# model -- but a control that covers a different stretch of the epoch than the
+# thing it is controlling is not a control at all. Setting
+# ALIGN_TO_POWER_TRACES_RUN to a windowed-ANOVA run directory overrides
+# WINDOW_TMIN/WINDOW_TMAX with the extent that run's windows actually tiled.
+#
+#   ALIGN_TO_POWER_TRACES_RUN=/path/to/within_elec_anova/<run_label> \
+#       bash submit_stability_flexibility_segregation_dcc.sh
+ALIGN_TO_POWER_TRACES_RUN = os.environ.get('ALIGN_TO_POWER_TRACES_RUN')
+_ALIGNMENT_NOTE = None
+if ALIGN_TO_POWER_TRACES_RUN:
+    from src.analysis.stats.power_traces_conjunction import (
+        analysis_window_from_run, describe_window_alignment)
+    _ALIGNMENT_NOTE = describe_window_alignment(
+        ALIGN_TO_POWER_TRACES_RUN, WINDOW_TMIN, WINDOW_TMAX)
+    WINDOW_TMIN, WINDOW_TMAX = analysis_window_from_run(ALIGN_TO_POWER_TRACES_RUN)
+
 # --- analysis options (default to the original behaviour) ---
 # contrast_mode : 'condition'  -> stability=congruency(i vs c), flexibility=switchType(s vs r)
 #                 'proportion' -> stability=incongruent_proportion, flexibility=switch_proportion
@@ -134,6 +158,13 @@ def run_analysis():
     print(f"Task:             {TASK}")
     print(f"Epochs file:      {EPOCHS_ROOT_FILE}")
     print(f"Analysis window:  [{WINDOW_TMIN}, {WINDOW_TMAX}] s")
+    if _ALIGNMENT_NOTE:
+        print("Window aligned to a power_traces electrode-definition run; this "
+              "continuous correlation is the CONFOUND CONTROL for that run's "
+              "2x2 counts (responsiveness residualisation + disjoint trial "
+              "halves), not an independent headline result.")
+        for _line in _ALIGNMENT_NOTE.splitlines():
+            print(f"  {_line}")
     print(f"Electrodes:       {ELECTRODES} | ROIs: {list(ROIS_DICT.keys()) if ROIS_DICT else 'all'}")
     print(f"Contrast mode:    {CONTRAST_MODE}")
     print(f"Effect measure:   {EFFECT_MEASURE}")

--- a/dcc_scripts/stats/stability_flexibility_segregation_dcc.py
+++ b/dcc_scripts/stats/stability_flexibility_segregation_dcc.py
@@ -87,7 +87,11 @@ def assemble_long_df(subjects_epochs, tmin, tmax, electrodes_to_keep=None,
                 = metadata block proportions (for contrast_mode='proportion')
     electrode   = f"{subject}-{channel}"  (unique across subjects)
     """
-    cluster = (effect_measure == 'cluster')
+    # Both time-resolved measures need the per-trial time COURSE. 'peak_t'
+    # was previously excluded here, so it silently received window means and
+    # collapsed to a single-bin t -- losing exactly the duration-invariance
+    # it exists to provide.
+    cluster = effect_measure in ('cluster', 'peak_t')
     frames = []
     for sub, epochs in subjects_epochs.items():
         md = epochs.metadata
@@ -155,7 +159,11 @@ def make_synthetic_df(rho_true=0.4, n_subj=10, seed=0, gain_sd=0.5,
     INTERACTION, so contrast_mode='proportion' has recoverable signal. When
     effect_measure='cluster', emits per-trial HG *time courses* (the effect
     injected into the middle of the window) instead of scalar window means."""
-    cluster = (effect_measure == 'cluster')
+    # Both time-resolved measures need the per-trial time COURSE. 'peak_t'
+    # was previously excluded here, so it silently received window means and
+    # collapsed to a single-bin t -- losing exactly the duration-invariance
+    # it exists to provide.
+    cluster = effect_measure in ('cluster', 'peak_t')
     rng = np.random.default_rng(seed)
     cov = np.array([[0.4**2, rho_true*0.16], [rho_true*0.16, 0.4**2]])
     rows = []

--- a/docs/stability_flexibility_guide.md
+++ b/docs/stability_flexibility_guide.md
@@ -601,6 +601,67 @@ find a shared code, which is weaker.
 can be a genuinely shared representation *or* mixed selectivity with orthogonal
 codes. Counting cannot tell them apart.
 
+### 5.1 The division of labour: counts are the result, the correlation is the control
+
+When the labels come from the cluster-corrected windowed ANOVA
+(`power_traces_conjunction`, §4a), the **2×2 counts are the primary result** and
+the continuous correlation is **the confound control for them** — not a second
+headline. The reason is that the count test has two confounds it cannot correct,
+and *both bias it toward "shared"*, which is usually the hypothesis under test:
+
+1. **Per-electrode detection power.** An electrode with high SNR or more trials is
+   likelier to clear α on *both* interactions from power alone, inflating the
+   "both" cell. Subject stratification does not help — the variation is across
+   electrodes *within* a subject.
+2. **Shared trial noise.** S and F labels are estimated from the same trials, so
+   coupled noise inflates co-occurrence. (The continuous route uses disjoint
+   halves; the categorical route does not.)
+
+The continuous route carries the correction for exactly those two — responsiveness
+residualisation (`prepare_continuous`) and disjoint trial halves
+(`compute_sensitivities`) — so its job is to show the count result is not
+manufactured by either.
+
+**Two consequences for how it is run and reported.**
+
+*It must cover the same stretch of the epoch.* It stays an independent estimate
+(different estimator, different temporal model), but a control that looks at
+different data than the thing it controls is not a control. The windowed-ANOVA run
+writes `run_config.json` with the extent its windows tiled; point the segregation
+launcher at it:
+
+```bash
+ALIGN_TO_POWER_TRACES_RUN=/path/to/within_elec_anova/<run_label> \
+    bash submit_stability_flexibility_segregation_dcc.sh
+```
+
+This overrides `WINDOW_TMIN`/`WINDOW_TMAX` and prints the alignment it applied.
+Note the alignment is of *extent only* — the ANOVA fits per sliding window and
+cluster-corrects across them, while the segregation estimator integrates over the
+whole extent. The two do not become equivalent, and should not be described as
+such.
+
+*Run every effect measure, not one.* Reducing a per-trial time course to one
+scalar is under-determined — mass grows with duration and is mildly trial-count
+sensitive, Cohen's *d* on the window mean attenuates transient effects, peak *t*
+is amplitude-only. As a **headline** that arbitrariness is a real weakness. As a
+**control** it is not, *provided the verdict does not depend on the choice* — so
+`continuous_confound_control` runs all three and reports the range.
+Disagreement in sign across measures is itself the finding and must be reported,
+not resolved by picking the convenient one.
+
+Reporting template: "The 2×2 conjunction gives MH OR = […]. Because a count test
+cannot correct for per-electrode detection power or shared trial noise, both of
+which inflate co-occurrence, we repeated the analysis continuously over the same
+analysis window, residualising each electrode's sensitivity on its overall
+responsiveness and estimating the two sensitivities on disjoint trial halves.
+ρ = […] to […] across the three effect measures."
+
+One asymmetry to keep straight: a **null correlation is not evidence for
+distinctness**. Only the count test's OR < 1 can supply that (see the box above).
+So the control can *undermine* a shared-core claim but cannot *establish* a
+segregated one.
+
 ---
 
 ## 6. Anatomy — brain maps, ROI histograms, coverage-conditioned test (§3 → Fig 5)

--- a/src/analysis/power/windowed_anova.py
+++ b/src/analysis/power/windowed_anova.py
@@ -504,6 +504,36 @@ def run_within_electrode_windowed_anova_cluster_correction(
         with open(run_dir / 'significant_effects_structure.json', 'w') as f:
             json.dump(sig_struct, f, indent=2)
 
+        # Run manifest. The window geometry in particular has to survive the run:
+        # any analysis that wants to be comparable to this one (e.g. the
+        # continuous segregation correlation, which is estimated independently
+        # but must cover the SAME stretch of time to be interpretable alongside
+        # these labels) needs to know the exact extent the windows tiled, and
+        # `window_centers` alone understates it by half a window at each end.
+        with open(run_dir / 'run_config.json', 'w') as f:
+            json.dump({
+                'window_centers': [float(w) for w in window_centers],
+                'window_size': int(window_size),
+                'step_size': int(step_size),
+                'sampling_rate': float(sampling_rate),
+                'n_windows': int(n_windows),
+                'times_min': float(times[0]),
+                'times_max': float(times[-1]),
+                # the extent actually covered by the windows, in seconds
+                'analysis_tmin': float(times[win_to_samples[0][0]]),
+                'analysis_tmax': float(times[win_to_samples[-1][1]]),
+                'anova_factors': list(anova_factors),
+                'effect_names': list(effect_names),
+                'rois': list(rois),
+                'subjects': list(subjects),
+                'n_perm': int(n_perm),
+                'percentile': float(percentile),
+                'cluster_percentile': float(cluster_percentile),
+                'min_trials_per_cell': int(min_trials_per_cell),
+                'split_clusters_by_sign': bool(split_clusters_by_sign),
+                'seed': int(seed),
+            }, f, indent=2)
+
     return results, window_centers, summary_df, skipped
 
 def load_significant_electrodes(within_elec_anova_run_dir, roi=None, effect=None,

--- a/src/analysis/stats/power_traces_conjunction.py
+++ b/src/analysis/stats/power_traces_conjunction.py
@@ -412,6 +412,190 @@ def electrode_labels(runs, roi=None, alpha=0.05, correction='fdr_bh',
 
 
 # ----------------------------------------------------------------------------
+# window alignment: making the independent continuous route comparable
+# ----------------------------------------------------------------------------
+def load_run_config(run_dir):
+    """Read a windowed-ANOVA run's `run_config.json`.
+
+    Falls back to reconstructing the window geometry from any per-electrode
+    `.npz` (which stores `window_centers`) for runs written before the manifest
+    existed. In that fallback `analysis_tmin`/`analysis_tmax` are the first and
+    last window CENTRES, which understates the true extent by half a window at
+    each end -- the returned dict flags this as `exact=False`.
+    """
+    run_dir = Path(run_dir)
+    cfg_path = run_dir / 'run_config.json'
+    if cfg_path.exists():
+        cfg = json.loads(cfg_path.read_text())
+        cfg['exact'] = True
+        return cfg
+
+    for npz_path in sorted(run_dir.glob('*/*/*.npz')):
+        with np.load(npz_path, allow_pickle=True) as z:
+            if 'window_centers' not in z:
+                continue
+            centers = np.asarray(z['window_centers'], float)
+        return dict(window_centers=[float(c) for c in centers],
+                    n_windows=int(centers.size),
+                    analysis_tmin=float(centers.min()),
+                    analysis_tmax=float(centers.max()),
+                    exact=False)
+
+    raise FileNotFoundError(
+        f"{run_dir} has neither run_config.json nor any per-electrode .npz; "
+        "cannot recover the window geometry")
+
+
+def analysis_window_from_run(run_dir):
+    """`(tmin, tmax)` in seconds covered by a windowed-ANOVA run.
+
+    This is what an independently-estimated analysis should be told to use so it
+    describes the same stretch of the epoch. It is NOT a claim that the two
+    analyses become equivalent -- the windowed ANOVA fits per sliding window and
+    cluster-corrects across them, while a single-window estimator integrates over
+    the whole extent. Aligning the extent only removes the trivial objection that
+    the two were looking at different data.
+    """
+    cfg = load_run_config(run_dir)
+    return float(cfg['analysis_tmin']), float(cfg['analysis_tmax'])
+
+
+def describe_window_alignment(run_dir, current_tmin, current_tmax):
+    """Human-readable diff between a segregation window and a power_traces run."""
+    cfg = load_run_config(run_dir)
+    tmin, tmax = float(cfg['analysis_tmin']), float(cfg['analysis_tmax'])
+    lines = [
+        f"power_traces run: {run_dir}",
+        f"  windows        : {cfg.get('n_windows', '?')} "
+        f"(size={cfg.get('window_size', '?')} samples, "
+        f"step={cfg.get('step_size', '?')})",
+        f"  covered extent : [{tmin:.4f}, {tmax:.4f}] s"
+        + ("" if cfg.get('exact') else "   (window CENTRES only -- no "
+                                        "run_config.json; true extent is wider)"),
+        f"  current window : [{current_tmin:.4f}, {current_tmax:.4f}] s",
+    ]
+    if abs(tmin - current_tmin) > 1e-9 or abs(tmax - current_tmax) > 1e-9:
+        lines.append("  -> MISALIGNED; the continuous estimate covers a "
+                     "different stretch of the epoch than the labels.")
+    else:
+        lines.append("  -> aligned.")
+    return '\n'.join(lines)
+
+
+# ----------------------------------------------------------------------------
+# the continuous route, in its confound-control role
+# ----------------------------------------------------------------------------
+def _window_mean_df(df):
+    """Collapse an array-valued `hg` column to its per-trial window mean."""
+    if df['hg'].dtype != object:
+        return df
+    return df.assign(hg=df['hg'].apply(lambda a: float(np.nanmean(a))))
+
+
+def continuous_confound_control(df, responsiveness=None, n_splits=200,
+                                n_perm=10000, min_elec=3,
+                                contrast_mode='proportion', contrasts=None,
+                                effect_measures=('peak_t', 'cluster', 'cohens_d'),
+                                alpha=0.05, seed=1):
+    """Run the continuous correlation under EVERY effect measure, as a control.
+
+    Why this shape. The count test (`run_power_traces_conjunction`) is the primary
+    result, but it has two confounds that both bias it toward "shared", which is
+    usually the hypothesis under test:
+
+      1. Per-electrode detection power. An electrode with high SNR or more trials
+         is likelier to clear alpha on BOTH interactions from power alone, which
+         inflates the "both" cell. Subject stratification does not fix this --
+         the variation is across electrodes within a subject.
+      2. Shared trial noise. S and F labels are estimated from the same trials, so
+         coupled noise inflates co-occurrence.
+
+    The continuous route carries the controls for exactly those two: it
+    residualises each sensitivity on the electrode's overall responsiveness
+    (`add_responsiveness` + `prepare_continuous`), and it estimates the two
+    sensitivities on DISJOINT trial halves (`compute_sensitivities`). Its job here
+    is to check that the count result is not manufactured by either -- not to be a
+    second headline.
+
+    Why all three measures rather than one pinned choice. Reducing a per-trial HG
+    time course to one scalar is under-determined: mass grows with duration and is
+    mildly trial-count sensitive, Cohen's d on the window mean attenuates transient
+    effects, peak t is amplitude-only. As a headline that arbitrariness is a real
+    weakness. As a CONTROL it is not, provided the verdict does not depend on the
+    choice -- so run all three and report the range. Divergence across measures is
+    itself the finding, and should be reported rather than resolved by picking the
+    convenient one.
+
+    Returns dict keyed by effect measure, each with `rho`, `p`, `n_electrodes`,
+    `n_subjects`, plus a top-level `agreement` summary.
+    """
+    from src.analysis.stats.stability_flexibility_segregation import (
+        add_responsiveness, compute_sensitivities, prepare_continuous,
+        subject_clustered_corr)
+
+    out = {}
+    for measure in effect_measures:
+        # 'cohens_d' standardises by a scalar pooled SD and is only defined on
+        # window-mean HG; 'cluster' and 'peak_t' need the time course. When the
+        # table carries time courses, reduce a copy for the window-mean measure
+        # -- the same reduction `_anova_interaction_stats` applies.
+        use = _window_mean_df(df) if measure == 'cohens_d' else df
+        elec = add_responsiveness(
+            compute_sensitivities(use, n_splits, contrast_mode=contrast_mode,
+                                  contrasts=contrasts, effect_measure=measure,
+                                  alpha=alpha),
+            use, responsiveness)
+        cont = prepare_continuous(elec, min_elec=min_elec)
+        corr = subject_clustered_corr(cont, n_perm=n_perm, seed=seed)
+        out[measure] = dict(
+            rho=float(corr['corr']), p=float(corr['p']),
+            n_electrodes=int(corr['n_electrodes']),
+            n_subjects=int(corr['n_subjects']))
+
+    rhos = [v['rho'] for v in out.values()]
+    ps = [v['p'] for v in out.values()]
+    out['agreement'] = dict(
+        rho_min=float(min(rhos)), rho_max=float(max(rhos)),
+        all_same_sign=bool(all(r > 0 for r in rhos) or all(r < 0 for r in rhos)),
+        all_significant=bool(all(p < alpha for p in ps)),
+        all_null=bool(all(p >= alpha for p in ps)),
+    )
+    return out
+
+
+def summarize_confound_control(res, alpha=0.05):
+    """One-screen readout of `continuous_confound_control`, with the verdict."""
+    lines = ["continuous correlation (responsiveness-residualised, "
+             "disjoint trial halves, within-subject centred):"]
+    for measure, v in res.items():
+        if measure == 'agreement':
+            continue
+        lines.append(f"    {measure:<10} rho = {v['rho']:+.3f}  p = {v['p']:.4g}"
+                     f"   ({v['n_electrodes']} electrodes, "
+                     f"{v['n_subjects']} subjects)")
+    a = res['agreement']
+    lines.append(f"  rho range across measures: "
+                 f"[{a['rho_min']:+.3f}, {a['rho_max']:+.3f}]")
+    if not a['all_same_sign']:
+        lines.append("  -> MEASURES DISAGREE IN SIGN. The continuous estimate is "
+                     "not stable under the scalarisation choice; report this "
+                     "rather than picking one.")
+    elif a['all_significant'] and a['rho_min'] > 0:
+        lines.append("  -> Positive under every measure: co-selectivity survives "
+                     "responsiveness residualisation and disjoint halves, so the "
+                     "count result is not explained by shared gain or shared "
+                     "trial noise.")
+    elif a['all_null']:
+        lines.append("  -> Null under every measure. Note a null correlation is "
+                     "NOT evidence for distinctness; only the count test's "
+                     "OR < 1 can supply that.")
+    else:
+        lines.append("  -> Mixed significance across measures; treat the control "
+                     "as inconclusive.")
+    return '\n'.join(lines)
+
+
+# ----------------------------------------------------------------------------
 # the count test
 # ----------------------------------------------------------------------------
 def both_vs_distinct_test(labels, n_perm=10000, seed=0):

--- a/src/analysis/stats/stability_flexibility_segregation.py
+++ b/src/analysis/stats/stability_flexibility_segregation.py
@@ -398,10 +398,29 @@ def _stack(vals):
     return np.vstack([np.asarray(v, float) for v in vals])
 
 
+def _require_scalar_hg(arr, effect_measure):
+    """Guard: 'cohens_d' is only defined on scalar (window-mean) HG.
+
+    `_cohens_d` / `_interaction_cohens_d` standardise a per-time-bin mean by a
+    SCALAR pooled SD, so handing them time courses returns a length-T vector
+    rather than one number. That propagates silently into `compute_sensitivities`
+    as an array-valued sensitivity and corrupts the correlation instead of
+    failing. Assemble the table with window means for 'cohens_d', or use
+    'cluster' / 'peak_t' for time courses.
+    """
+    if effect_measure == 'cohens_d' and np.ndim(arr) > 1 and arr.shape[1] > 1:
+        raise ValueError(
+            "effect_measure='cohens_d' requires scalar (window-mean) hg, but the "
+            f"table holds time courses of length {arr.shape[1]}. Either build the "
+            "long table with window means, or use effect_measure='cluster' / "
+            "'peak_t', which are defined on time courses.")
+
+
 def _effect_from_arrays(hg, lab, effect_measure, alpha):
     """Effect between the label==1 and label==0 trials of one electrode."""
     pos = _stack(hg[lab == 1])
     neg = _stack(hg[lab == 0])
+    _require_scalar_hg(pos, effect_measure)
     if effect_measure == 'cluster':
         return _cluster_effect(pos, neg, alpha=alpha)
     if effect_measure == 'peak_t':
@@ -503,6 +522,7 @@ def _interaction_effect(hg, cond, mod, effect_measure, alpha):
     cells = _dod_cells(hg[valid], cond[valid], mod[valid])
     if cells is None:
         return np.nan
+    _require_scalar_hg(next(iter(cells.values())), effect_measure)
     if effect_measure == 'cluster':
         return _interaction_cluster(cells, alpha)
     if effect_measure == 'peak_t':
@@ -1000,7 +1020,7 @@ def _synthetic_df(effect_measure='cohens_d', n_time=20, seed=0):
                       congruency=cong, switchType=sw,
                       incongruent_proportion=inc_prop, switch_proportion=sw_prop)
             frame = pd.DataFrame(fr)
-            if effect_measure == 'cluster':
+            if effect_measure in ('cluster', 'peak_t'):   # both need time courses
                 tc = rng.normal(0, 1, (n_tr, n_time)) * gain
                 w = slice(n_time // 4, 3 * n_time // 4)
                 tc[:, w] += (gain * base)[:, None]

--- a/tests/analysis/stats/test_power_traces_conjunction.py
+++ b/tests/analysis/stats/test_power_traces_conjunction.py
@@ -419,3 +419,163 @@ def test_sweep_present_only_with_fdr(four_runs):
 def test_bad_correction_mode_raises(four_runs):
     with pytest.raises(ValueError, match='correction must be'):
         ptc.electrode_labels(four_runs, roi='lpfc', correction='bonferroni')
+
+
+# ----------------------------------------------------------------------------
+# window alignment
+# ----------------------------------------------------------------------------
+def _write_run_config(run_dir, tmin, tmax, n_windows=8, window_size=4, step=2):
+    (run_dir / 'run_config.json').write_text(json.dumps({
+        'window_centers': list(np.linspace(tmin, tmax, n_windows)),
+        'window_size': window_size, 'step_size': step, 'sampling_rate': 256.0,
+        'n_windows': n_windows, 'times_min': tmin, 'times_max': tmax,
+        'analysis_tmin': tmin, 'analysis_tmax': tmax,
+        'anova_factors': ['congruency', 'incongruentProportion'],
+        'effect_names': [CPC_EFFECT], 'rois': ['lpfc'], 'subjects': ['S1'],
+        'n_perm': 100, 'percentile': 95.0, 'cluster_percentile': 95.0,
+        'min_trials_per_cell': 2, 'split_clusters_by_sign': True, 'seed': 42,
+    }))
+
+
+def test_analysis_window_read_from_run_config(tmp_path):
+    run = tmp_path / 'r'
+    run.mkdir()
+    _write_run_config(run, -0.2, 0.8)
+    assert ptc.analysis_window_from_run(run) == pytest.approx((-0.2, 0.8))
+    assert ptc.load_run_config(run)['exact'] is True
+
+
+def test_window_falls_back_to_npz_centres_and_flags_inexactness(tmp_path):
+    """Legacy run: only window centres survive, which understate the true extent
+    by half a window at each end. The caller must be able to tell."""
+    run = tmp_path / 'r'
+    _write_npz(run, 'lpfc', 'S1', 'e0', np.zeros((1, 6)),
+               np.zeros((5, 1, 6)), [CPC_EFFECT])
+    cfg = ptc.load_run_config(run)
+    assert cfg['exact'] is False
+    assert ptc.analysis_window_from_run(run) == pytest.approx((0.0, 5.0))
+
+
+def test_missing_geometry_raises(tmp_path):
+    (tmp_path / 'bare').mkdir()
+    with pytest.raises(FileNotFoundError, match='window geometry'):
+        ptc.load_run_config(tmp_path / 'bare')
+
+
+def test_describe_alignment_detects_mismatch(tmp_path):
+    run = tmp_path / 'r'
+    run.mkdir()
+    _write_run_config(run, -0.2, 0.8)
+    assert 'MISALIGNED' in ptc.describe_window_alignment(run, 0.0, 0.5)
+    assert 'aligned.' in ptc.describe_window_alignment(run, -0.2, 0.8)
+
+
+def test_describe_alignment_warns_when_extent_is_inexact(tmp_path):
+    run = tmp_path / 'r'
+    _write_npz(run, 'lpfc', 'S1', 'e0', np.zeros((1, 6)),
+               np.zeros((5, 1, 6)), [CPC_EFFECT])
+    assert 'CENTRES only' in ptc.describe_window_alignment(run, 0.0, 5.0)
+
+
+# ----------------------------------------------------------------------------
+# the continuous route as confound control
+# ----------------------------------------------------------------------------
+@pytest.fixture(scope='module')
+def timecourse_df():
+    """Small long-format table with per-trial HG TIME COURSES.
+
+    Mirrors the structure of `stability_flexibility_segregation._synthetic_df`
+    (per-electrode gain, LWPC and LWPS interactions, 75/25 proportion cells) but
+    sized for a fast test. Kept local so the test does not import the DCC entry
+    point, which pulls in `ieeg`.
+    """
+    rng = np.random.default_rng(0)
+    n_time = 8
+    frames = []
+    for s in range(5):
+        n_tr = 160
+        cong = rng.choice(['c', 'i'], n_tr)
+        sw = rng.choice(['s', 'r'], n_tr)
+        inc_prop = rng.choice([25.0, 75.0], n_tr)
+        sw_prop = rng.choice([25.0, 75.0], n_tr)
+        for e in range(6):
+            gain = rng.lognormal(0, 0.5)              # the gain confound
+            b = rng.normal(0, 0.4)                    # shared x/y sensitivity
+            bx, by = b + rng.normal(0, .1), b + rng.normal(0, .1)
+            base = (bx * (cong == 'i') * (1.0 + (inc_prop == 75.0))
+                    + by * (sw == 's') * (1.0 + (sw_prop == 75.0)))
+            tc = rng.normal(0, 1, (n_tr, n_time)) * gain
+            tc[:, n_time // 4:3 * n_time // 4] += (gain * base)[:, None]
+            col = np.empty(n_tr, dtype=object)
+            for i in range(n_tr):
+                col[i] = tc[i]
+            frames.append(pd.DataFrame(dict(
+                subject=s, electrode=f'{s}_{e}', congruency=cong, switchType=sw,
+                incongruent_proportion=inc_prop, switch_proportion=sw_prop,
+                hg=col)))
+    return pd.concat(frames, ignore_index=True)
+
+
+def test_confound_control_runs_every_measure(timecourse_df):
+    res = ptc.continuous_confound_control(
+        timecourse_df, n_splits=8, n_perm=200, contrast_mode='proportion')
+    for m in ('peak_t', 'cluster', 'cohens_d'):
+        assert m in res
+        assert np.isfinite(res[m]['rho'])
+        assert 0 < res[m]['p'] <= 1
+        assert res[m]['n_electrodes'] > 0
+
+
+def test_cohens_d_is_reduced_to_window_means_not_crashed(timecourse_df):
+    """The table holds time courses; cohens_d is only defined on scalars, so the
+    battery must reduce a copy rather than propagate an array-valued sensitivity."""
+    assert timecourse_df['hg'].dtype == object          # really time courses
+    res = ptc.continuous_confound_control(
+        timecourse_df, n_splits=8, n_perm=100,
+        contrast_mode='proportion', effect_measures=('cohens_d',))
+    assert np.isscalar(res['cohens_d']['rho'])
+    assert np.isfinite(res['cohens_d']['rho'])
+
+
+def test_cohens_d_on_timecourses_raises_when_called_directly(timecourse_df):
+    """The guard itself: without it this silently returns a length-T vector."""
+    from src.analysis.stats.stability_flexibility_segregation import (
+        compute_sensitivities)
+    with pytest.raises(ValueError, match="requires scalar"):
+        compute_sensitivities(timecourse_df, n_splits=2,
+                              contrast_mode='proportion',
+                              effect_measure='cohens_d')
+
+
+def test_agreement_block_reports_range_and_sign(timecourse_df):
+    res = ptc.continuous_confound_control(
+        timecourse_df, n_splits=8, n_perm=200, contrast_mode='proportion')
+    a = res['agreement']
+    rhos = [res[m]['rho'] for m in ('peak_t', 'cluster', 'cohens_d')]
+    assert a['rho_min'] == pytest.approx(min(rhos))
+    assert a['rho_max'] == pytest.approx(max(rhos))
+    assert isinstance(a['all_same_sign'], bool)
+
+
+def test_summary_flags_sign_disagreement():
+    res = {'peak_t': dict(rho=0.4, p=0.01, n_electrodes=50, n_subjects=8),
+           'cluster': dict(rho=-0.3, p=0.02, n_electrodes=50, n_subjects=8),
+           'agreement': dict(rho_min=-0.3, rho_max=0.4, all_same_sign=False,
+                             all_significant=True, all_null=False)}
+    assert 'DISAGREE IN SIGN' in ptc.summarize_confound_control(res)
+
+
+def test_summary_states_null_is_not_evidence_for_distinctness():
+    res = {'peak_t': dict(rho=0.01, p=0.8, n_electrodes=50, n_subjects=8),
+           'agreement': dict(rho_min=0.01, rho_max=0.01, all_same_sign=True,
+                             all_significant=False, all_null=True)}
+    text = ptc.summarize_confound_control(res)
+    assert 'NOT evidence for distinctness' in text
+
+
+def test_summary_confirms_control_when_all_positive():
+    res = {'peak_t': dict(rho=0.4, p=0.001, n_electrodes=50, n_subjects=8),
+           'agreement': dict(rho_min=0.4, rho_max=0.4, all_same_sign=True,
+                             all_significant=True, all_null=False)}
+    text = ptc.summarize_confound_control(res)
+    assert 'survives' in text


### PR DESCRIPTION
…ound control

When the 2x2 counts come from the cluster-corrected windowed ANOVA, the continuous correlation is the confound control for those counts rather than a second headline. The count test cannot correct for per-electrode detection power (a high-SNR electrode clears alpha on both interactions from power alone) or for shared trial noise (S and F are estimated from the same trials), and both inflate co-occurrence -- i.e. both bias toward "shared". The continuous route carries exactly those two corrections: responsiveness residualisation and disjoint trial halves.

It stays an independent estimate, but a control that covers a different stretch of the epoch than the thing it controls is not a control:

- windowed_anova now writes run_config.json with the window geometry, including the extent the windows actually tiled (window_centers alone understates it by half a window at each end).
- power_traces_conjunction.analysis_window_from_run / load_run_config / describe_window_alignment read it back, falling back to npz window centres for older runs and flagging that extent as inexact.
- The segregation launcher takes ALIGN_TO_POWER_TRACES_RUN=<run_dir>, which overrides WINDOW_TMIN/WINDOW_TMAX and prints the alignment applied.

continuous_confound_control runs the correlation under all three effect measures and reports the range. Scalarising a time course is under-determined, which is a real weakness for a headline result but not for a control, provided the verdict does not depend on the choice. Sign disagreement across measures is surfaced as a finding rather than resolved by picking one.

Fixes two latent bugs this exposed:

- assemble_long_df and _synthetic_df built time courses only for effect_measure='cluster', so 'peak_t' silently received window means and collapsed to a single-bin t, losing the duration-invariance it exists to provide.
- 'cohens_d' standardises a per-bin mean by a scalar pooled SD, so on time courses it returned a length-T vector that propagated into compute_sensitivities as an array-valued sensitivity and corrupted the correlation silently. Now raises with a message naming the fix; continuous_confound_control reduces a window-mean copy for that measure.

Guide section 5.1 documents the division of labour, the alignment command, and a reporting template, and restates that a null correlation is not evidence for distinctness.

85 tests pass.


Claude-Session: https://claude.ai/code/session_01UTdKfeq4w3YLFAQVJkEY4D