### PR TITLE
Add a DCC job for the power_traces-defined conjunction

### DIFF
--- a/dcc_scripts/stats/README.md
+++ b/dcc_scripts/stats/README.md
@@ -373,3 +373,112 @@ being *stronger* than the cross pairing (`specificity_ok`) at both levels. The
 across-subject correlation is reported with its *n* and an honest underpowered
 caveat — a null there is uninformative; the within-subject mixed model is the real
 test.
+
+---
+
+# A1′/A2 — Conjunction on `power_traces` cluster-corrected electrodes
+
+Same conjunction as the A1/A2 job above, with the **electrode definition
+swapped**. Instead of one ANOVA on window-mean HG, the S/F flags are read back
+from a finished **within-electrode windowed ANOVA + cluster-correction** run
+(`src/analysis/power/windowed_anova.py`, launched by
+`dcc_scripts/power/run_power_traces_dcc.py` with `ANOVA_UNIT='electrode'`), which
+fits the ANOVA at every window and cluster-corrects across time. Bridge code:
+`src/analysis/stats/power_traces_conjunction.py`; rationale in guide §4/§4a/§5.1.
+
+Nothing here re-fits an ANOVA. The count test is a **pure read** of a finished
+run, so it costs seconds, needs no epoched data, and can be re-run at several
+alphas / corrections for free.
+
+## Files
+
+| File | Role |
+|---|---|
+| `power_traces_conjunction_dcc.py` | Core: resolves the run dir(s), builds labels, runs the count battery, optionally the continuous confound control, writes results + figures. Exposes `main(args)`. |
+| `run_power_traces_conjunction_dcc.py` | Entrypoint: sets parameters (env-overridable) and calls `main`. |
+| `sbatch_power_traces_conjunction_dcc.sh` | SLURM wrapper (`conda activate ieeg` → entrypoint). |
+| `submit_power_traces_conjunction_dcc.sh` | Sets `PT_RUN`/ROI/correction and `sbatch`-submits. |
+
+## Quick start
+
+```bash
+cd dcc_scripts/stats
+
+# validate the whole path in seconds against a KNOWN planted overlap:
+DATA_SOURCE=synthetic bash submit_power_traces_conjunction_dcc.sh
+# the NULL version (overlap == base rate — MH OR must come back ≈ 1):
+DATA_SOURCE=synthetic SYNTHETIC_OVERLAP=0.25 bash submit_power_traces_conjunction_dcc.sh
+
+# real: point PT_RUN at a finished within-electrode ANOVA run, then
+bash submit_power_traces_conjunction_dcc.sh
+RUN_CONTINUOUS=1 bash submit_power_traces_conjunction_dcc.sh   # + confound control
+```
+
+A **run directory** is the one holding `summary.csv` + `run_config.json`:
+`dcc_scripts/power/figs/<EPOCHS_ROOT_FILE>/anova_within_electrode/<conditions_save_name>`.
+
+## What it does
+
+1. **Labels.** `ptc.electrode_labels` reads the run's `summary.csv`, pivots the
+   four interactions (CPC/SPS/CPS/SPC) onto one row per electrode, and corrects
+   **across electrodes** — the family a test that *counts electrodes* needs.
+   `summary.csv` carries every electrode that was **tested**, not just the
+   winners, which is what makes the 2×2 denominator honest.
+2. **Counts.** `ptc.run_power_traces_conjunction`: CMH (subject-stratified),
+   within-subject permutation null on the joint count, shared-vs-distinct, the
+   two cross-interaction specificity controls, and a threshold sweep.
+3. **Confound control** (optional, `RUN_CONTINUOUS=1` — the only step that loads
+   epochs). Re-estimates each electrode's two sensitivities on **disjoint trial
+   halves**, residualised on responsiveness, over the **same window the run
+   tiled** (read from `run_config.json`, not from `WINDOW_TMIN/TMAX`), and under
+   **all three** effect measures. It is the control on the counts, not a second
+   headline (guide §5.1).
+
+## Key knobs (env vars)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `PT_RUN` | — | One run whose ANOVA held all four factors (`stimulus_experiment_conditions`). Preferred: all four interactions then come from the same electrodes and trials. |
+| `PT_RUN_CPC` / `_SPS` / `_CPS` / `_SPC` | — | Or four separate two-factor runs. Only CPC and SPS are required. |
+| `ROIS` | `lpfc` | Comma-separated ROI names, or `all` for one analysis pooled over ROIs. Each ROI gets its own output subdirectory. |
+| `CORRECTION` | `fdr_bh` | `fdr_bh` = BH across electrodes within (roi, effect); `cluster` = raw cluster p < α, no across-electrode correction (the like-for-like port of what `load_significant_electrodes` does today); `none` = any surviving cluster. |
+| `ALPHA` | `0.05` | Selection cutoff. |
+| `REQUIRE_ALL` | `1` | Keep only electrodes present in every requested run — different runs can end up with different electrode sets (`min_trials_per_cell`), and a 2×2 over inconsistent denominators is not interpretable. |
+| `USE_NPZ` | `1` | Legacy runs only (no `best_cluster_p` column): recompute a graded cluster p per electrode from the saved `.npz` null. |
+| `N_PERM_NULL` / `THRESHOLDS` | `10000` / `0.01,0.025,0.05,0.10` | Permutation count and sweep cutoffs. |
+| `RUN_CONTINUOUS` | `0` | `1` also runs the continuous confound control (needs `EPOCHS_ROOT_FILE`). |
+| `EFFECT_MEASURES` | `peak_t,cluster,cohens_d` | Which scalarisations the control runs. Run all three: divergence in sign is itself the finding. |
+| `N_SPLITS` / `N_PERM_CORR` / `MIN_ELEC` / `ELECTRODES` | `200` / `10000` / `3` / `all` | Control-only knobs (as in the segregation job). |
+
+## Outputs
+
+Written to `power_traces_conjunction_results/<run_tag>/<correction>_alpha<α>/<roi>/`:
+
+- `labels.csv` — one row per electrode: `p_/q_/<g>_sign/<g>_extent` per group, the
+  binary CPC/SPS/CPS/SPC flags, and the `S`/`F` aliases.
+- `conjunction.json`, `conjunction_per_subject.csv` — MH OR, CMH p, homogeneity p,
+  pooled 2×2, per-subject tables.
+- `counts.json` — the four cells plus both permutation tests.
+- `joint_count_null.npy`, `shared_minus_distinct_null.npy` — the raw nulls.
+- `cross_controls.csv`, `threshold_sweep.csv`.
+- `power_traces_conjunction_summary.png` (6 panels) and
+  `power_traces_conjunction_evidence.png` (q-values + cluster extents).
+- `continuous_confound_control.json` — ρ and p per effect measure, when run.
+- `summary.txt` — printed verdicts.
+
+**Reading:** MH `OR < 1` / overlap below null → **segregation**; `OR > 1` /
+overlap above null → **shared core**; ≈1 → independent.
+
+Two things the summary flags, because both read as findings if you skip them:
+
+- **`shared − distinct` is the same test as the joint count.** With the marginals
+  fixed by the within-subject shuffle, `D = 3·both − n_S − n_F`, so it is a
+  monotone function of the `both` count and returns an identical p. Both are
+  printed so the equivalence is visible — never report them as two lines of
+  evidence.
+- **Degenerate sweep rows.** `cmh_conjunction` uses `StratifiedTable(...,
+  shift_zeros=True)`. At a cutoff where nothing is selected, the shift turns
+  `[[0,0],[0,n]]` into `[[.5,.5],[.5,n+.5]]` — a large OR and a tiny p out of a
+  table with no selected electrodes in it. Rows with an empty marginal or
+  `n_both = 0` are named in `summary.txt` and drawn hollow (and excluded from the
+  trend line) in the sweep panel.

--- a/dcc_scripts/stats/power_traces_conjunction_dcc.py
+++ b/dcc_scripts/stats/power_traces_conjunction_dcc.py
@@ -1,0 +1,598 @@
+#!/usr/bin/env python
+"""
+DCC core for the conjunction driven by `power_traces` electrode definitions.
+
+This is the A1/A2 layer again, but with the ELECTRODE DEFINITION swapped: instead
+of fitting one ANOVA on window-mean HG (`sfs.per_electrode_anova_labels`, run by
+`stability_flexibility_anova_conjunction_dcc.py`), the S/F flags are read back
+from a within-electrode WINDOWED ANOVA + cluster-correction run
+(`src/analysis/power/windowed_anova.py`, launched by
+`dcc_scripts/power/run_power_traces_dcc.py` with `ANOVA_UNIT='electrode'`).
+
+  1. `ptc.electrode_labels` reads the run's `summary.csv`, pivots the four
+     interactions (CPC/SPS/CPS/SPC) onto one row per electrode, and applies the
+     across-electrode correction the 2x2 needs (BH by default).
+  2. `ptc.run_power_traces_conjunction` runs the count battery on those labels:
+     CMH, within-subject permutation null on the joint count, shared-vs-distinct,
+     the two cross-interaction specificity controls, and a threshold sweep.
+  3. OPTIONALLY (`--run-continuous`) the continuous CONFOUND CONTROL for those
+     counts: `ptc.continuous_confound_control` re-estimates each electrode's two
+     sensitivities on DISJOINT trial halves, residualised on responsiveness, over
+     the SAME stretch of the epoch the windowed-ANOVA run tiled, under all three
+     effect measures. This is the only step that needs the epoched data, and it
+     is a control on the counts -- not a second headline (guide §5.1).
+
+Driven by `run_power_traces_conjunction_dcc.py` (wrapped by
+`sbatch_power_traces_conjunction_dcc.sh`). Not run directly on the cluster; call
+`main(args)` with a populated argument namespace.
+
+Nothing here re-fits an ANOVA: step 1-2 are pure reads of a finished
+`power_traces` run, so they are cheap and can be re-run at several alphas /
+corrections without touching the epochs.
+"""
+
+import warnings
+warnings.simplefilter(action='ignore', category=FutureWarning)
+
+import sys
+import os
+import json
+
+# ---------------------------------------------------------------------------
+# PATH SETUP (mirrors the other dcc_scripts entrypoints)
+# ---------------------------------------------------------------------------
+try:
+    current_file_path = os.path.abspath(__file__)
+    current_script_dir = os.path.dirname(current_file_path)
+except NameError:
+    current_script_dir = os.getcwd()
+
+project_root = os.path.abspath(os.path.join(current_script_dir, '..', '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+if os.path.exists("/hpc/home"):
+    USER = os.environ.get('USER')
+    sys.path.append(f"/hpc/home/{USER}/coganlab/{USER}/GlobalLocal/IEEG_Pipelines/")
+
+import numpy as np
+import pandas as pd
+
+import matplotlib
+matplotlib.use('Agg')          # headless / cluster
+import matplotlib.pyplot as plt
+
+from src.analysis.stats import power_traces_conjunction as ptc
+# NOTE: `general_utils` (and through it `mne`) is imported lazily inside
+# `run_continuous_control`. The count test is a pure read of a finished run, so
+# it must stay runnable in an environment with no epoched-data stack at all.
+
+STAB, FLEX = "#2c7fb8", "#d95f0e"
+
+
+# ---------------------------------------------------------------------------
+# run-directory resolution
+# ---------------------------------------------------------------------------
+def resolve_runs(args):
+    """`{group: run_dir}` for `ptc.electrode_labels`, from the args namespace.
+
+    Two shapes, matching how `power_traces` was actually launched:
+
+      * ONE run whose ANOVA held all four factors (`stimulus_experiment_conditions`,
+        `anova_factors=['congruency','incongruentProportion','switchType',
+        'switchProportion']`) -- pass `args.run_dir`, and every interaction is read
+        from that single `summary.csv`.
+      * FOUR separate two-factor runs (`stimulus_lwpc_conditions`,
+        `stimulus_lwps_conditions`, `stimulus_congruency_by_switch_proportion_conditions`,
+        `stimulus_switch_type_by_incongruent_proportion_conditions`) -- pass
+        `args.run_dirs` as a `{group: path}` dict.
+
+    The four-run shape is allowed to be partial: only CPC and SPS are required
+    (the S x F table needs those two), the cross controls are reported when present.
+    """
+    if getattr(args, 'run_dirs', None):
+        runs = {g: p for g, p in args.run_dirs.items() if p}
+    elif getattr(args, 'run_dir', None):
+        runs = args.run_dir
+    else:
+        raise ValueError(
+            "no power_traces run given: set PT_RUN to a single 4-factor "
+            "within-electrode ANOVA run directory, or PT_RUN_CPC / PT_RUN_SPS "
+            "(+ optionally PT_RUN_CPS / PT_RUN_SPC) to four separate runs.")
+
+    for group, path in ([('run', runs)] if isinstance(runs, str)
+                        else sorted(runs.items())):
+        if not os.path.isdir(path):
+            raise FileNotFoundError(f"{group}: not a directory: {path}")
+        if not os.path.exists(os.path.join(path, 'summary.csv')):
+            raise FileNotFoundError(
+                f"{group}: no summary.csv in {path}. Point at the run directory "
+                "written by run_within_electrode_windowed_anova_cluster_correction "
+                "(i.e. <SAVE_DIR>/anova_within_electrode/<conditions_save_name>), "
+                "not its parent.")
+    return runs
+
+
+def rois_in_run(runs):
+    """ROI names present in the run(s), from `summary.csv`'s `roi` column."""
+    paths = [runs] if isinstance(runs, str) else list(runs.values())
+    rois = set()
+    for p in paths:
+        rois |= set(pd.read_csv(os.path.join(p, 'summary.csv'))['roi'].unique())
+    return sorted(str(r) for r in rois)
+
+
+# ---------------------------------------------------------------------------
+# synthetic run directories (path / plumbing validation, no cluster data)
+# ---------------------------------------------------------------------------
+def make_synthetic_runs(save_dir, n_subj=8, n_elec=25, overlap=0.6, base_rate=0.25,
+                        roi='lpfc', seed=0, tmin=0.0, tmax=1.5, n_windows=30):
+    """Write four fake within-electrode ANOVA runs to disk and return their paths.
+
+    Plants a KNOWN degree of S/F co-selectivity so the whole read -> label ->
+    conjunction path can be validated without a real run: `overlap` is the
+    probability that an S electrode is also F, against a base rate `base_rate` of
+    each selectivity. `overlap > base_rate` should come back as MH OR > 1;
+    `overlap == base_rate` is the null and should come back ~1.
+
+    The two cross interactions are drawn at the null, so the specificity controls
+    should stay near-empty -- which is what makes the synthetic run a real check
+    on the cross-control panel and not just on the plumbing.
+    """
+    rng = np.random.default_rng(seed)
+    effects = {
+        'CPC': ptc.anova_effect_name('congruency', 'incongruentProportion'),
+        'SPS': ptc.anova_effect_name('switchType', 'switchProportion'),
+        'CPS': ptc.anova_effect_name('congruency', 'switchProportion'),
+        'SPC': ptc.anova_effect_name('switchType', 'incongruentProportion'),
+    }
+    rows = {g: [] for g in effects}
+    for s in range(n_subj):
+        for e in range(n_elec):
+            sub, elec = f"S{s:02d}", f"e{e:02d}"
+            is_s = rng.random() < base_rate
+            # P(F) is base_rate either way, but conditioned on S it is `overlap`
+            p_f = overlap if is_s else max(
+                0.0, (base_rate - base_rate * overlap) / (1 - base_rate))
+            flags = dict(CPC=is_s, SPS=rng.random() < p_f,
+                         CPS=rng.random() < 0.02, SPC=rng.random() < 0.02)
+            for g, eff in effects.items():
+                sig = flags[g]
+                # a graded p either side of the cutoff, so BH has something to rank
+                p = float(rng.uniform(0.0001, 0.01) if sig
+                          else rng.uniform(0.2, 1.0))
+                ext = int(rng.integers(3, 9)) if sig else int(rng.integers(0, 2))
+                sgn = int(rng.choice([-1, 1])) if sig else 0
+                rows[g].append(dict(
+                    subject=sub, electrode=elec, roi=roi, effect=eff,
+                    cluster_idx=0 if sig else -1, sign=sgn, extent_windows=ext,
+                    cluster_onset=0.1, cluster_offset=0.3,
+                    cluster_p_value=p if sig else 1.0,
+                    best_cluster_p=p, best_cluster_extent=ext,
+                    best_cluster_sign=sgn,
+                    peak_F=float(rng.uniform(1, 12)), peak_time=0.2))
+
+    centers = np.linspace(tmin, tmax, n_windows)
+    out = {}
+    for g, rs in rows.items():
+        run_dir = os.path.join(save_dir, 'synthetic_runs', g.lower())
+        os.makedirs(run_dir, exist_ok=True)
+        pd.DataFrame(rs).to_csv(os.path.join(run_dir, 'summary.csv'), index=False)
+        with open(os.path.join(run_dir, 'run_config.json'), 'w') as f:
+            json.dump(dict(window_centers=[float(c) for c in centers],
+                           window_size=50, step_size=10, sampling_rate=256.0,
+                           n_windows=int(n_windows),
+                           analysis_tmin=float(tmin), analysis_tmax=float(tmax),
+                           rois=[roi], subjects=[f"S{s:02d}" for s in range(n_subj)]),
+                      f, indent=2)
+        out[g] = run_dir
+    return out
+
+
+# ---------------------------------------------------------------------------
+# serialization helpers
+# ---------------------------------------------------------------------------
+def _json_safe(o):
+    if isinstance(o, dict):
+        return {k: _json_safe(v) for k, v in o.items()}
+    if isinstance(o, (list, tuple)):
+        return [_json_safe(v) for v in o]
+    if isinstance(o, np.ndarray):
+        return o.tolist()
+    if isinstance(o, (np.floating, np.integer)):
+        return o.item()
+    return o
+
+
+def save_results(labels, res, save_dir):
+    """Write the label table, the conjunction/null JSONs, and the raw nulls."""
+    os.makedirs(save_dir, exist_ok=True)
+    labels.to_csv(os.path.join(save_dir, 'labels.csv'), index=False)
+    res['cross_controls'].to_csv(
+        os.path.join(save_dir, 'cross_controls.csv'), index=False)
+    if 'sweep' in res:
+        res['sweep'].to_csv(os.path.join(save_dir, 'threshold_sweep.csv'),
+                            index=False)
+
+    conj = res['cmh']
+    conj_json = dict(
+        mh_odds_ratio=conj['mh_odds_ratio'],
+        cmh_pvalue=conj['cmh'].pvalue, cmh_statistic=conj['cmh'].statistic,
+        homogeneity_pvalue=conj['homogeneity'].pvalue,
+        homogeneity_statistic=conj['homogeneity'].statistic,
+        pooled_table=conj['pooled_table'],
+        pooled_fisher_or=conj['pooled_fisher_or'],
+        pooled_fisher_p=conj['pooled_fisher_p'],
+        labels=res['attrs'])
+    if 'or_95ci' in conj:
+        conj_json['mh_or_95ci'] = list(conj['or_95ci'])
+    with open(os.path.join(save_dir, 'conjunction.json'), 'w') as f:
+        json.dump(_json_safe(conj_json), f, indent=2)
+    conj['per_subject'].to_csv(
+        os.path.join(save_dir, 'conjunction_per_subject.csv'), index=False)
+
+    null, bvd = res['joint_count_null'], res['both_vs_distinct']
+    counts_json = dict(
+        n_electrodes=bvd['n_electrodes'], n_subjects=bvd['n_subjects'],
+        n_both=bvd['n_both'], n_stab_only=bvd['n_stab_only'],
+        n_flex_only=bvd['n_flex_only'], n_neither=bvd['n_neither'],
+        joint_count=dict(observed=null['observed'],
+                         null_mean=float(np.mean(null['null'])),
+                         null_std=float(np.std(null['null'])),
+                         p_two_sided=null['p_two_sided'], z=null['z'],
+                         n_perm=int(len(null['null']))),
+        shared_minus_distinct=dict(
+            observed=bvd['observed'], null_mean=bvd['null_mean'],
+            null_sd=bvd['null_sd'], p_shared_greater=bvd['p_shared_greater'],
+            p_two_sided=bvd['p_two_sided'], z=bvd['z'],
+            n_perm=int(len(bvd['null'])),
+            # documented in both_vs_distinct_test: with the marginals fixed by the
+            # within-subject shuffle, D = 3*both - n_S - n_F, so this is the SAME
+            # test as the joint count above -- reported, not double-counted.
+            equivalent_to_joint_count=True))
+    with open(os.path.join(save_dir, 'counts.json'), 'w') as f:
+        json.dump(_json_safe(counts_json), f, indent=2)
+    np.save(os.path.join(save_dir, 'joint_count_null.npy'), null['null'])
+    np.save(os.path.join(save_dir, 'shared_minus_distinct_null.npy'), bvd['null'])
+
+
+def save_continuous(control, save_dir):
+    with open(os.path.join(save_dir, 'continuous_confound_control.json'), 'w') as f:
+        json.dump(_json_safe(control), f, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# threshold-sweep hygiene
+# ---------------------------------------------------------------------------
+def degenerate_sweep_rows(sweep):
+    """Boolean mask of sweep rows whose odds ratio is an artifact, not a result.
+
+    `cmh_conjunction` builds each subject's 2x2 with `StratifiedTable(...,
+    shift_zeros=True)`, which adds 0.5 to every cell of a table containing a
+    zero. That is the standard fix for a single empty cell, but at a strict
+    cutoff where NOTHING is selected the table is `[[0, 0], [0, n]]` and the
+    shift turns it into `[[.5, .5], [.5, n + .5]]` -- an odds ratio that grows
+    with the number of unselected electrodes and a vanishing p-value, out of a
+    table with no selected electrodes in it at all. Read literally, the sweep
+    then reports its STRONGEST shared-core evidence exactly where it has no
+    evidence.
+
+    A row is only informative if both marginals are non-empty; a row with
+    `n_both == 0` is additionally driven entirely by the shift. Flag both, and
+    keep them out of the plotted trend line.
+    """
+    s = sweep
+    return ((s['n_S'] == 0) | (s['n_F'] == 0) | (s['n_both'] == 0)).to_numpy()
+
+
+def _sweep_warning(sweep):
+    bad = degenerate_sweep_rows(sweep)
+    if not bad.any():
+        return []
+    ts = ", ".join(f"q<{t}" for t in sweep.loc[bad, 'threshold'])
+    return ["  WARNING: sweep row(s) " + ts + " have an empty marginal or "
+            "n_both = 0. Their OR/p come from StratifiedTable's shift_zeros "
+            "correction on an (almost) empty table, not from data -- ignore "
+            "them when judging whether the verdict is threshold-stable."]
+
+
+# ---------------------------------------------------------------------------
+# figures
+# ---------------------------------------------------------------------------
+def make_plots(labels, res, save_dir, roi_tag=''):
+    lab = labels
+    null, bvd, conj = res['joint_count_null'], res['both_vs_distinct'], res['cmh']
+
+    fig, ax = plt.subplots(2, 3, figsize=(16, 9))
+
+    # A: selectivity classes
+    ax[0, 0].bar(["neither", "S only", "F only", "both"],
+                 [bvd['n_neither'], bvd['n_stab_only'], bvd['n_flex_only'],
+                  bvd['n_both']],
+                 color=["#ccc", STAB, FLEX, "#31a354"])
+    ax[0, 0].set(title=f"electrode selectivity classes{roi_tag}\n"
+                       f"(power_traces cluster-corrected definition)",
+                 ylabel="# electrodes")
+
+    # B: pooled 2x2 + MH OR
+    pooled = np.asarray(conj['pooled_table'])
+    ax[0, 1].imshow(pooled, cmap="Blues")
+    ax[0, 1].set_xticks([0, 1]); ax[0, 1].set_xticklabels(["F=1", "F=0"])
+    ax[0, 1].set_yticks([0, 1]); ax[0, 1].set_yticklabels(["S=1", "S=0"])
+    for (i, j), v in np.ndenumerate(pooled):
+        ax[0, 1].text(j, i, int(v), ha="center", va="center",
+                      color="white" if v > pooled.max() / 2 else "black", fontsize=13)
+    ax[0, 1].set(title=f"pooled 2x2 (MH OR={conj['mh_odds_ratio']:.2f}, "
+                       f"CMH p={conj['cmh'].pvalue:.3g})")
+
+    # C: within-subject null on the joint count
+    ax[0, 2].hist(null['null'], bins=40, color="#bbb")
+    ax[0, 2].axvline(null['observed'], color="#d7191c", lw=2,
+                     label=f"observed = {null['observed']}")
+    ax[0, 2].legend()
+    ax[0, 2].set(title=f"within-subject null on 'both'\n"
+                       f"p={null['p_two_sided']:.3g}, z={null['z']:+.2f}",
+                 xlabel="# 'both' electrodes", ylabel="# permutations")
+
+    # D: shared - distinct (same test as C; plotted to make the identity visible)
+    ax[1, 0].hist(bvd['null'], bins=40, color="#bbb")
+    ax[1, 0].axvline(bvd['observed'], color="#d7191c", lw=2,
+                     label=f"observed = {bvd['observed']}")
+    ax[1, 0].legend()
+    ax[1, 0].set(title=f"shared - distinct (monotone in 'both':\n"
+                       f"same test as the panel above, p={bvd['p_two_sided']:.3g})",
+                 xlabel="both - (S-only + F-only)", ylabel="# permutations")
+
+    # E: threshold sweep. Degenerate rows (empty marginal / no 'both') are drawn
+    # as hollow markers and kept OUT of the trend line -- see
+    # `degenerate_sweep_rows` for why their OR is an artifact of shift_zeros.
+    if 'sweep' in res and len(res['sweep']):
+        sw = res['sweep']
+        bad = degenerate_sweep_rows(sw)
+        ok = sw[~bad]
+        if len(ok):
+            ax[1, 1].plot(ok['threshold'], ok['mh_odds_ratio'], 'o-',
+                          color="#31a354", label="informative")
+        if bad.any():
+            ax[1, 1].plot(sw.loc[bad, 'threshold'], sw.loc[bad, 'mh_odds_ratio'],
+                          'o', mfc='none', color="#999",
+                          label="degenerate (empty cell)")
+        ax[1, 1].axhline(1.0, ls='--', c='k', lw=1, label="OR = 1 (independence)")
+        ax[1, 1].legend(fontsize=8)
+        ax[1, 1].set(title="overlap OR vs selection threshold",
+                     xlabel="q-value cutoff", ylabel="MH odds ratio")
+    else:
+        ax[1, 1].text(.5, .5, "no q-values\n(correction='cluster' / 'none')",
+                      ha='center', va='center', transform=ax[1, 1].transAxes)
+        ax[1, 1].set(title="overlap OR vs selection threshold")
+
+    # F: cross-interaction specificity controls
+    cc = res['cross_controls']
+    if len(cc):
+        colors = {'CPC': STAB, 'SPS': FLEX, 'CPS': "#8856a7", 'SPC': "#7fbf7b"}
+        ax[1, 2].bar(cc['group'], 100 * cc['frac'],
+                     color=[colors.get(g, "#999") for g in cc['group']])
+        for xi, (n, fr) in enumerate(zip(cc['n_significant'], cc['frac'])):
+            ax[1, 2].text(xi, 100 * fr, f"{int(n)}", ha='center', va='bottom')
+    ax[1, 2].set(title="cross controls (CPS/SPC should be near-null)",
+                 ylabel="% of electrodes selected")
+
+    fig.tight_layout()
+    fig_path = os.path.join(save_dir, 'power_traces_conjunction_summary.png')
+    fig.savefig(fig_path, dpi=140, bbox_inches='tight')
+    plt.close(fig)
+    print(f"saved figure: {fig_path}")
+
+    # a second, smaller figure: the graded evidence behind the flags
+    if 'p_cpc' in lab.columns:
+        fig2, ax2 = plt.subplots(1, 2, figsize=(11, 4.5))
+        qx = 'q_cpc' if lab['q_cpc'].notna().any() else 'p_cpc'
+        qy = 'q_sps' if lab['q_sps'].notna().any() else 'p_sps'
+        ax2[0].scatter(lab[qx], lab[qy], c=lab['S'] + 2 * lab['F'],
+                       cmap="viridis", s=20, alpha=.75)
+        ax2[0].axvline(res['attrs'].get('alpha', .05), ls='--', c='k', lw=1)
+        ax2[0].axhline(res['attrs'].get('alpha', .05), ls='--', c='k', lw=1)
+        ax2[0].set(title="per-electrode evidence (dashed = alpha)",
+                   xlabel=f"{qx} (stability / LWPC)",
+                   ylabel=f"{qy} (flexibility / LWPS)",
+                   xlim=(-.02, 1.02), ylim=(-.02, 1.02))
+        ax2[1].scatter(lab['cpc_extent'], lab['sps_extent'], s=20, alpha=.6,
+                       color="#444")
+        ax2[1].set(title="cluster extent (windows) per electrode",
+                   xlabel="CPC extent", ylabel="SPS extent")
+        fig2.tight_layout()
+        p2 = os.path.join(save_dir, 'power_traces_conjunction_evidence.png')
+        fig2.savefig(p2, dpi=140, bbox_inches='tight')
+        plt.close(fig2)
+        print(f"saved figure: {p2}")
+
+
+# ---------------------------------------------------------------------------
+# text summary
+# ---------------------------------------------------------------------------
+def write_summary(labels, res, save_dir, meta, control=None, alpha=0.05):
+    lines = [
+        "=" * 72,
+        "STABILITY vs FLEXIBILITY - CONJUNCTION ON power_traces ELECTRODES",
+        "=" * 72,
+    ]
+    for key, val in meta.items():
+        lines.append(f"{key:>26}: {val}")
+    lines += ["-" * 72, ptc.summarize(res)]
+    if 'sweep' in res and len(res['sweep']):
+        lines += _sweep_warning(res['sweep'])
+    if labels.attrs.get('n_dropped'):
+        lines.append(f"  NOTE: {labels.attrs['n_dropped']} electrode(s) dropped -- "
+                     "not present in every requested run (require_all=True). A 2x2 "
+                     "built over inconsistent denominators is not interpretable.")
+    if control is not None:
+        lines += ["-" * 72, ptc.summarize_confound_control(control, alpha=alpha)]
+    else:
+        lines += ["-" * 72,
+                  "continuous confound control: NOT RUN. The count test cannot "
+                  "correct for per-electrode detection power or shared trial "
+                  "noise, and both bias it toward 'shared'. Re-run with "
+                  "RUN_CONTINUOUS=1 before reporting a shared-core claim."]
+    lines += [
+        "=" * 72,
+        "Reading: MH OR < 1 / overlap below null -> segregation (distinct "
+        "populations); OR > 1 / overlap above null -> shared core; ~1 -> independent.",
+        "Note 'shared - distinct' is a monotone function of the 'both' count under "
+        "this null, so it is the SAME test as the joint-count permutation -- not a "
+        "second, independent line of evidence.",
+    ]
+    txt = "\n".join(str(x) for x in lines)
+    with open(os.path.join(save_dir, 'summary.txt'), 'w') as f:
+        f.write(txt + "\n")
+    print(txt)
+
+
+# ---------------------------------------------------------------------------
+# the continuous confound control (the only step that touches the epochs)
+# ---------------------------------------------------------------------------
+def run_continuous_control(args, labels, runs, save_dir):
+    """Re-estimate the two sensitivities continuously over the run's own window.
+
+    Three things make this a control on the counts rather than a separate result:
+    the window comes from the run's `run_config.json` (same stretch of epoch), the
+    electrode universe is restricted to the electrodes the labels were built on,
+    and all three effect measures are run so the verdict cannot hinge on the
+    scalarisation choice (guide §5.1).
+    """
+    from dcc_scripts.stats.stability_flexibility_segregation_dcc import (
+        assemble_long_df, make_synthetic_df)
+    from src.analysis.utils.general_utils import (
+        resolve_lab_root, resolve_electrodes_to_keep)
+
+    ref_run = runs if isinstance(runs, str) else runs['CPC']
+    tmin, tmax = ptc.analysis_window_from_run(ref_run)
+    print(ptc.describe_window_alignment(ref_run, tmin, tmax))
+    print(f"continuous control window: [{tmin:.4f}, {tmax:.4f}] s "
+          "(taken from the run, not from WINDOW_TMIN/TMAX)")
+
+    if args.data_source == 'synthetic':
+        df = make_synthetic_df(rho_true=getattr(args, 'synthetic_rho', 0.4),
+                               effect_measure='cluster')
+    else:
+        LAB_root = resolve_lab_root(args.LAB_root)
+        from src.analysis.utils.general_utils import load_HG_ev1_rescaled_per_subject
+        subjects_epochs = load_HG_ev1_rescaled_per_subject(
+            subjects=args.subjects, epochs_root_file=args.epochs_root_file,
+            task=args.task, LAB_root=LAB_root, acc_trials_only=args.acc_trials_only)
+        keep = resolve_electrodes_to_keep(args, LAB_root)
+        # `assemble_long_df` needs time courses for peak_t / cluster; 'cohens_d'
+        # is taken on the window mean of the same courses inside the control.
+        df = assemble_long_df(subjects_epochs, tmin, tmax,
+                              electrodes_to_keep=keep, effect_measure='cluster')
+
+        # Restrict to the electrodes the labels are defined on. The long table
+        # names electrodes '<subject>-<channel>'; the run's summary.csv keeps the
+        # channel and the subject in separate columns.
+        wanted = {f"{s}-{e}" for s, e in
+                  zip(labels['subject'], labels['electrode'])}
+        before = df['electrode'].nunique()
+        df = df[df['electrode'].isin(wanted)].reset_index(drop=True)
+        after = df['electrode'].nunique()
+        print(f"continuous control electrodes: {after} of {before} in the long "
+              f"table matched the {len(wanted)} labelled electrodes")
+        if after == 0:
+            raise RuntimeError(
+                "no electrode in the assembled long table matched the labelled "
+                "electrodes. Check that the power_traces run and this job were "
+                "given the same subjects / ROI / epochs file.")
+
+    control = ptc.continuous_confound_control(
+        df, responsiveness=getattr(args, 'responsiveness', None),
+        n_splits=args.n_splits, n_perm=args.n_perm_corr,
+        min_elec=args.min_elec, alpha=args.alpha,
+        effect_measures=tuple(args.effect_measures), seed=getattr(args, 'seed', 1))
+    save_continuous(control, save_dir)
+    return control
+
+
+# ---------------------------------------------------------------------------
+# one ROI's worth of work
+# ---------------------------------------------------------------------------
+def run_one_roi(args, runs, roi, save_dir):
+    os.makedirs(save_dir, exist_ok=True)
+    print("=" * 72)
+    print(f"ROI: {roi if roi is not None else 'all (pooled across ROIs)'}")
+    print(f"save_dir: {save_dir}")
+
+    labels = ptc.electrode_labels(
+        runs, roi=roi, alpha=args.alpha, correction=args.correction,
+        use_npz=args.use_npz, require_all=args.require_all)
+    print(f"labels: {len(labels)} electrodes | "
+          f"{labels['subject'].nunique()} subjects | "
+          f"dropped {labels.attrs.get('n_dropped', 0)} (not in every run)")
+
+    res = ptc.run_power_traces_conjunction(
+        labels, n_perm=args.n_perm_null, seed=getattr(args, 'seed', 0),
+        thresholds=tuple(args.thresholds))
+
+    save_results(labels, res, save_dir)
+    make_plots(labels, res, save_dir,
+               roi_tag=f"  [{roi}]" if roi is not None else "")
+    return labels, res
+
+
+# ---------------------------------------------------------------------------
+# orchestrator
+# ---------------------------------------------------------------------------
+def main(args):
+    os.makedirs(args.save_dir, exist_ok=True)
+
+    if args.data_source == 'synthetic':
+        print("DATA SOURCE: synthetic (writes fake within-electrode ANOVA runs)")
+        runs = make_synthetic_runs(
+            args.save_dir, overlap=getattr(args, 'synthetic_overlap', 0.6),
+            base_rate=getattr(args, 'synthetic_base_rate', 0.25),
+            seed=getattr(args, 'seed', 0))
+        args.run_dirs, args.run_dir = runs, None
+    else:
+        print("DATA SOURCE: real power_traces within-electrode ANOVA run(s)")
+
+    runs = resolve_runs(args)
+    if isinstance(runs, str):
+        print(f"single 4-factor run: {runs}")
+    else:
+        for g, p in sorted(runs.items()):
+            print(f"  {g}: {p}")
+
+    available = rois_in_run(runs)
+    print(f"ROIs present in the run(s): {available}")
+    if args.rois in (None, 'all', ['all']):
+        roi_list = [None]                      # one pooled analysis
+    else:
+        roi_list = list(args.rois)
+        missing = [r for r in roi_list if r not in available]
+        if missing:
+            raise ValueError(f"requested ROI(s) {missing} are not in the run; "
+                             f"available: {available}")
+
+    out = {}
+    for roi in roi_list:
+        tag = roi if roi is not None else 'all_rois'
+        roi_dir = os.path.join(args.save_dir, tag)
+        labels, res = run_one_roi(args, runs, roi, roi_dir)
+
+        control = None
+        if getattr(args, 'run_continuous', False):
+            print("-" * 72)
+            print("continuous confound control (disjoint trial halves, "
+                  "responsiveness-residualised, all effect measures)")
+            control = run_continuous_control(args, labels, runs, roi_dir)
+
+        write_summary(labels, res, roi_dir, alpha=args.alpha, control=control,
+                      meta=dict(
+                          data_source=args.data_source,
+                          runs=(runs if isinstance(runs, str)
+                                else {g: os.path.basename(p) for g, p in runs.items()}),
+                          roi=tag, correction=args.correction, alpha=args.alpha,
+                          require_all=args.require_all,
+                          n_perm_null=args.n_perm_null,
+                          thresholds=list(args.thresholds),
+                          continuous_control=bool(getattr(args, 'run_continuous', False)),
+                          save_dir=roi_dir))
+        out[tag] = dict(labels=labels, results=res, continuous=control)
+    return out

--- a/dcc_scripts/stats/run_power_traces_conjunction_dcc.py
+++ b/dcc_scripts/stats/run_power_traces_conjunction_dcc.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python
+"""
+Entrypoint for the conjunction on `power_traces`-defined electrodes.
+Sets up input args and calls power_traces_conjunction_dcc.main().
+Wrapped by sbatch_power_traces_conjunction_dcc.sh for cluster submission.
+
+The electrode definition is READ BACK from a finished within-electrode windowed
+ANOVA + cluster-correction run (`dcc_scripts/power/run_power_traces_dcc.py` with
+ANOVA_UNIT='electrode'), so this job does not re-fit anything unless the optional
+continuous confound control is enabled.
+
+Everything is overridable from the submit script via environment variables:
+
+    PT_RUN            one run directory whose ANOVA held all four factors
+                      (stimulus_experiment_conditions)
+    PT_RUN_CPC/_SPS/_CPS/_SPC
+                      or four separate two-factor runs (CPC and SPS required)
+    ROIS              comma-separated ROI names, or 'all' to pool
+    ALPHA, CORRECTION, N_PERM_NULL, THRESHOLDS, REQUIRE_ALL, USE_NPZ
+    RUN_CONTINUOUS    1 to also run the continuous confound control (needs epochs)
+    EPOCHS_ROOT_FILE, N_SPLITS, N_PERM_CORR, MIN_ELEC, EFFECT_MEASURES, ELECTRODES
+    DATA_SOURCE       'real' (default) or 'synthetic' (fabricates the runs on disk)
+"""
+import sys
+import os
+from types import SimpleNamespace
+from datetime import datetime
+
+# ---------------------------------------------------------------------------
+# PATH SETUP (detect cluster vs local, mirror the other run_* scripts)
+# ---------------------------------------------------------------------------
+if os.path.exists("/hpc/home"):
+    USER = os.environ.get('USER')
+    sys.path.append(f"/hpc/home/{USER}/coganlab/{USER}/GlobalLocal/IEEG_Pipelines/")
+    current_script_dir = os.path.dirname(os.path.abspath(__file__))
+else:
+    try:
+        current_script_dir = os.path.dirname(os.path.abspath(__file__))
+    except NameError:
+        current_script_dir = os.getcwd()
+
+project_root = os.path.abspath(os.path.join(current_script_dir, '..', '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from dcc_scripts.stats.power_traces_conjunction_dcc import main
+
+# ---------------------------------------------------------------------------
+# DATA SOURCE
+# ---------------------------------------------------------------------------
+# 'real'      -> read the run directories named below
+# 'synthetic' -> fabricate four runs on disk with a KNOWN planted overlap, so the
+#                read -> label -> conjunction path can be validated in seconds.
+DATA_SOURCE = os.environ.get('DATA_SOURCE', 'real')
+SYNTHETIC_OVERLAP = float(os.environ.get('SYNTHETIC_OVERLAP', '0.6'))
+SYNTHETIC_BASE_RATE = float(os.environ.get('SYNTHETIC_BASE_RATE', '0.25'))
+SYNTHETIC_RHO = float(os.environ.get('SYNTHETIC_RHO', '0.4'))   # continuous control
+
+# ---------------------------------------------------------------------------
+# WHICH power_traces RUN(S) DEFINE THE ELECTRODES
+# ---------------------------------------------------------------------------
+# A run directory is the one holding `summary.csv` + `run_config.json`, i.e.
+#   <dcc_scripts/power/figs>/<EPOCHS_ROOT_FILE>/anova_within_electrode/<conditions_save_name>
+# e.g. .../anova_within_electrode/stimulus_experiment_conditions_24_subjects
+PT_RUN = os.environ.get('PT_RUN')            # single 4-factor run, or None
+
+# ... or four separate two-factor runs. Only CPC and SPS are required; the two
+# cross runs are the specificity controls and may be omitted.
+PT_RUN_DIRS = {
+    'CPC': os.environ.get('PT_RUN_CPC'),     # congruency x incongruentProportion (LWPC)
+    'SPS': os.environ.get('PT_RUN_SPS'),     # switchType x switchProportion      (LWPS)
+    'CPS': os.environ.get('PT_RUN_CPS'),     # congruency x switchProportion      (cross)
+    'SPC': os.environ.get('PT_RUN_SPC'),     # switchType x incongruentProportion (cross)
+}
+PT_RUN_DIRS = {k: v for k, v in PT_RUN_DIRS.items() if v}
+
+# ---------------------------------------------------------------------------
+# LABEL / CONJUNCTION PARAMETERS
+# ---------------------------------------------------------------------------
+# ROIs to analyse. The labels are per-ROI, and so is the electrode universe --
+# note a subject with no electrodes in the ROI drops out of the CMH entirely.
+# 'all' runs ONE analysis pooled over every ROI in the run.
+ROIS = os.environ.get('ROIS', 'lpfc')
+ROIS = 'all' if ROIS.strip() == 'all' else [r.strip() for r in ROIS.split(',') if r.strip()]
+
+# correction across ELECTRODES, which is the family a count test needs:
+#   'fdr_bh'  BH within (roi, effect)                     [default, recommended]
+#   'cluster' raw cluster p < alpha, no across-electrode correction -- the
+#             like-for-like port of what load_significant_electrodes does today
+#   'none'    any surviving cluster counts
+CORRECTION = os.environ.get('CORRECTION', 'fdr_bh')
+ALPHA = float(os.environ.get('ALPHA', '0.05'))
+
+# Keep only electrodes present in EVERY requested run. Different runs can end up
+# with different electrode sets (min_trials_per_cell), and a 2x2 built over
+# inconsistent denominators is not interpretable.
+REQUIRE_ALL = os.environ.get('REQUIRE_ALL', '1') not in ('0', 'false', 'False')
+
+# Only consulted for legacy runs whose summary.csv predates `best_cluster_p`:
+# recompute a graded cluster p for every electrode from the saved .npz null.
+USE_NPZ = os.environ.get('USE_NPZ', '1') not in ('0', 'false', 'False')
+
+N_PERM_NULL = int(os.environ.get('N_PERM_NULL', '10000'))
+THRESHOLDS = [float(t) for t in
+              os.environ.get('THRESHOLDS', '0.01,0.025,0.05,0.10').split(',')]
+SEED = int(os.environ.get('SEED', '0'))
+
+# ---------------------------------------------------------------------------
+# CONTINUOUS CONFOUND CONTROL (optional; the only part that loads epochs)
+# ---------------------------------------------------------------------------
+# The count test above cannot correct for (a) per-electrode detection power or
+# (b) shared trial noise, and both bias it toward "shared". This re-estimates the
+# two sensitivities on DISJOINT trial halves, residualised on responsiveness,
+# over the SAME window the run tiled, under all three effect measures. It is the
+# control on the counts, not a second headline (guide §5.1).
+RUN_CONTINUOUS = os.environ.get('RUN_CONTINUOUS', '0') not in ('0', 'false', 'False')
+
+TASK = 'GlobalLocal'
+LAB_ROOT = None                      # auto-resolved in main()
+ACC_TRIALS_ONLY = True
+SUBJECTS = ['D0057', 'D0059', 'D0063', 'D0065', 'D0069', 'D0077', 'D0090',
+            'D0094', 'D0100', 'D0102', 'D0103', 'D0107A', 'D0110', 'D0116',
+            'D0117', 'D0121', 'D0133', 'D0134', 'D0137', 'D0138', 'D0139A',
+            'D0144', 'D0145', 'D0146']
+
+EPOCHS_ROOT_FILE = os.environ.get('EPOCHS_ROOT_FILE')
+if RUN_CONTINUOUS and DATA_SOURCE == 'real' and EPOCHS_ROOT_FILE is None:
+    raise ValueError("RUN_CONTINUOUS=1 needs EPOCHS_ROOT_FILE (the continuous "
+                     "control re-estimates from single trials). Set it via "
+                     "sbatch --export=ALL,EPOCHS_ROOT_FILE=... , or leave "
+                     "RUN_CONTINUOUS=0 to run the count test alone.")
+
+ELECTRODES = os.environ.get('ELECTRODES', 'all')            # 'all' or 'sig'
+# ROIS_DICT gates which channels are assembled for the continuous control. It has
+# no effect on the counts -- those come from the run's own ROI assignment.
+ROIS_DICT = {
+    'lpfc': ["G_front_inf-Opercular", "G_front_inf-Orbital", "G_front_inf-Triangul",
+             "G_front_middle", "G_front_sup", "Lat_Fis-ant-Horizont",
+             "Lat_Fis-ant-Vertical", "S_circular_insula_ant", "S_circular_insula_sup",
+             "S_front_inf", "S_front_middle", "S_front_sup"],
+    'occ':  ["G_cuneus", "G_and_S_occipital_inf", "G_occipital_middle",
+             "G_occipital_sup", "G_oc-temp_lat-fusifor", "G_oc-temp_med-Lingual",
+             "Pole_occipital", "S_calcarine", "S_oc_middle_and_Lunatus",
+             "S_oc_sup_and_transversal", "S_occipital_ant"],
+}
+RESPONSIVENESS = None      # prefer a {electrode: baseline-vs-signal cluster stat}
+N_SPLITS = int(os.environ.get('N_SPLITS', '200'))
+N_PERM_CORR = int(os.environ.get('N_PERM_CORR', '10000'))
+MIN_ELEC = int(os.environ.get('MIN_ELEC', '3'))
+EFFECT_MEASURES = [m.strip() for m in
+                   os.environ.get('EFFECT_MEASURES', 'peak_t,cluster,cohens_d').split(',')
+                   if m.strip()]
+
+# ---------------------------------------------------------------------------
+# OUTPUT
+# ---------------------------------------------------------------------------
+if DATA_SOURCE == 'synthetic':
+    _tag = f'synthetic_overlap{SYNTHETIC_OVERLAP}_base{SYNTHETIC_BASE_RATE}'
+else:
+    _ref = PT_RUN if PT_RUN else (PT_RUN_DIRS.get('CPC') or 'unknown_run')
+    _tag = os.path.basename(os.path.normpath(_ref))
+SAVE_DIR = os.path.join(current_script_dir, 'power_traces_conjunction_results',
+                        _tag, f'{CORRECTION}_alpha{ALPHA}')
+
+
+def run_analysis():
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    args = SimpleNamespace(
+        timestamp=timestamp,
+        data_source=DATA_SOURCE,
+        synthetic_overlap=SYNTHETIC_OVERLAP,
+        synthetic_base_rate=SYNTHETIC_BASE_RATE,
+        synthetic_rho=SYNTHETIC_RHO,
+        run_dir=PT_RUN,
+        run_dirs=PT_RUN_DIRS,
+        rois=ROIS,
+        alpha=ALPHA,
+        correction=CORRECTION,
+        require_all=REQUIRE_ALL,
+        use_npz=USE_NPZ,
+        n_perm_null=N_PERM_NULL,
+        thresholds=THRESHOLDS,
+        seed=SEED,
+        # continuous confound control
+        run_continuous=RUN_CONTINUOUS,
+        LAB_root=LAB_ROOT,
+        subjects=SUBJECTS,
+        task=TASK,
+        acc_trials_only=ACC_TRIALS_ONLY,
+        epochs_root_file=EPOCHS_ROOT_FILE,
+        electrodes=ELECTRODES,
+        rois_dict=ROIS_DICT,
+        responsiveness=RESPONSIVENESS,
+        n_splits=N_SPLITS,
+        n_perm_corr=N_PERM_CORR,
+        min_elec=MIN_ELEC,
+        effect_measures=EFFECT_MEASURES,
+        save_dir=SAVE_DIR,
+    )
+
+    print("=" * 72)
+    print("CONJUNCTION ON power_traces CLUSTER-CORRECTED ELECTRODES")
+    print("=" * 72)
+    print(f"Data source:      {DATA_SOURCE}"
+          + (f" (overlap={SYNTHETIC_OVERLAP}, base={SYNTHETIC_BASE_RATE})"
+             if DATA_SOURCE == 'synthetic' else ""))
+    if DATA_SOURCE == 'real':
+        if PT_RUN:
+            print(f"Run (4-factor):   {PT_RUN}")
+        for g, p in sorted(PT_RUN_DIRS.items()):
+            print(f"Run {g}:           {p}")
+    print(f"ROIs:             {ROIS}")
+    print(f"Correction:       {CORRECTION} | alpha: {ALPHA}")
+    print(f"require_all:      {REQUIRE_ALL} | use_npz (legacy runs): {USE_NPZ}")
+    print(f"n_perm_null:      {N_PERM_NULL} | thresholds: {THRESHOLDS}")
+    print("-" * 72)
+    print(f"Continuous control: {RUN_CONTINUOUS}")
+    if RUN_CONTINUOUS:
+        print(f"  Epochs file:    {EPOCHS_ROOT_FILE}")
+        print(f"  Electrodes:     {ELECTRODES} | ROIs: {list(ROIS_DICT.keys()) if ROIS_DICT else 'all'}")
+        print(f"  Effect measures:{EFFECT_MEASURES}")
+        print(f"  n_splits:       {N_SPLITS} | n_perm_corr: {N_PERM_CORR} | min_elec: {MIN_ELEC}")
+        print("  Window is taken from the run's run_config.json, NOT from "
+              "WINDOW_TMIN/TMAX -- a control that covers a different stretch of "
+              "the epoch than the counts is not a control.")
+    print(f"Save dir:         {SAVE_DIR}")
+    print("=" * 72)
+
+    try:
+        main(args)
+        print("\n✓ Analysis completed successfully!")
+    except Exception as e:
+        print(f"\n✗ Analysis failed with error: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    run_analysis()

--- a/dcc_scripts/stats/sbatch_power_traces_conjunction_dcc.sh
+++ b/dcc_scripts/stats/sbatch_power_traces_conjunction_dcc.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#SBATCH --output=out/slurm_%j.out
+#SBATCH -e out/slurm_%j.err
+#SBATCH -p common,scavenger,coganlab-gpu
+#SBATCH -c 8
+#SBATCH --mem=64G
+#SBATCH --time=12:00:00
+
+source $(conda info --base)/etc/profile.d/conda.sh
+
+conda activate ieeg  # make sure this env has scipy + statsmodels
+
+python /hpc/home/$USER/coganlab/$USER/GlobalLocal/dcc_scripts/stats/run_power_traces_conjunction_dcc.py

--- a/dcc_scripts/stats/submit_power_traces_conjunction_dcc.sh
+++ b/dcc_scripts/stats/submit_power_traces_conjunction_dcc.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Submit the conjunction on power_traces-defined electrodes.
+#
+# The electrode definition is READ BACK from a finished within-electrode windowed
+# ANOVA + cluster-correction run, so the count test costs seconds and needs no
+# epoched data. Only the optional continuous confound control loads epochs.
+#
+# Usage:
+#   DATA_SOURCE=synthetic bash submit_power_traces_conjunction_dcc.sh   # dry run
+#   bash submit_power_traces_conjunction_dcc.sh                         # real
+#   RUN_CONTINUOUS=1 bash submit_power_traces_conjunction_dcc.sh        # + control
+#
+# Run it first with DATA_SOURCE=synthetic: that fabricates four runs with a KNOWN
+# planted overlap (SYNTHETIC_OVERLAP vs SYNTHETIC_BASE_RATE), so a wrong answer
+# there is a plumbing bug, not a data finding. SYNTHETIC_OVERLAP=0.25
+# SYNTHETIC_BASE_RATE=0.25 is the null and must come back with MH OR ~ 1.
+
+# ---------------------------------------------------------------------------
+# The power_traces run(s) that define the electrodes.
+#
+# A run directory is the one holding summary.csv + run_config.json:
+#   <dcc_scripts/power/figs>/<EPOCHS_ROOT_FILE>/anova_within_electrode/<conditions_save_name>
+# Produce one with dcc_scripts/power/submit_specific_conditions_power_traces_dcc.sh
+# (ANOVA_UNIT=electrode).
+# ---------------------------------------------------------------------------
+FIGS_ROOT="/hpc/home/$USER/coganlab/$USER/GlobalLocal/dcc_scripts/power/figs"
+EPOCHS_ROOT_FILE="Stimulus_-1.0to1.5sec_0.5sec_within-1.0-0.0sec_base_decFactor_8_outliers_10_drop_thresh_perc_5.0_70.0-150.0_Hz_padLength_1.5s_filterbank_hilbert_stat_func_ttest_ind_equal_var_False_nan_policy_omit"
+
+# Option A (preferred): ONE run whose ANOVA held all four factors. Every
+# interaction — LWPC, LWPS and both cross controls — is read from its summary.csv,
+# so all four are defined on exactly the same electrodes and trials.
+PT_RUN="${PT_RUN:-$FIGS_ROOT/$EPOCHS_ROOT_FILE/anova_within_electrode/stimulus_experiment_conditions_24_subjects}"
+
+# Option B: four separate two-factor runs. Uncomment and unset PT_RUN above.
+# Only CPC and SPS are required; the cross runs are the specificity controls.
+# PT_RUN=""
+# PT_RUN_CPC="$FIGS_ROOT/$EPOCHS_ROOT_FILE/anova_within_electrode/stimulus_lwpc_conditions_24_subjects"
+# PT_RUN_SPS="$FIGS_ROOT/$EPOCHS_ROOT_FILE/anova_within_electrode/stimulus_lwps_conditions_24_subjects"
+# PT_RUN_CPS="$FIGS_ROOT/$EPOCHS_ROOT_FILE/anova_within_electrode/stimulus_congruency_by_switch_proportion_conditions_24_subjects"
+# PT_RUN_SPC="$FIGS_ROOT/$EPOCHS_ROOT_FILE/anova_within_electrode/stimulus_switch_type_by_incongruent_proportion_conditions_24_subjects"
+
+# ---------------------------------------------------------------------------
+# Label / conjunction knobs.
+# ---------------------------------------------------------------------------
+ROIS=${ROIS:-lpfc}                 # comma-separated, or 'all' to pool over ROIs
+CORRECTION=${CORRECTION:-fdr_bh}   # fdr_bh | cluster | none
+ALPHA=${ALPHA:-0.05}
+N_PERM_NULL=${N_PERM_NULL:-10000}
+THRESHOLDS=${THRESHOLDS:-0.01,0.025,0.05,0.10}
+REQUIRE_ALL=${REQUIRE_ALL:-1}
+
+# ---------------------------------------------------------------------------
+# Continuous confound control (loads epochs; off by default).
+# The count test cannot correct for per-electrode detection power or shared trial
+# noise, and both inflate the 'both' cell. Turn this on before reporting a
+# shared-core claim. Its window is taken from the run, not set here.
+# ---------------------------------------------------------------------------
+RUN_CONTINUOUS=${RUN_CONTINUOUS:-0}
+ELECTRODES=${ELECTRODES:-all}      # 'all' or 'sig'
+EFFECT_MEASURES=${EFFECT_MEASURES:-peak_t,cluster,cohens_d}
+N_SPLITS=${N_SPLITS:-50}
+N_PERM_CORR=${N_PERM_CORR:-1000}
+MIN_ELEC=${MIN_ELEC:-3}
+
+DATA_SOURCE=${DATA_SOURCE:-real}
+SYNTHETIC_OVERLAP=${SYNTHETIC_OVERLAP:-0.6}
+SYNTHETIC_BASE_RATE=${SYNTHETIC_BASE_RATE:-0.25}
+
+mkdir -p out
+
+echo "Submitting power_traces conjunction (source=$DATA_SOURCE, rois=$ROIS, correction=$CORRECTION)"
+sbatch --job-name="pt_conj_${DATA_SOURCE}" \
+    --export=ALL,DATA_SOURCE="$DATA_SOURCE",PT_RUN="$PT_RUN",PT_RUN_CPC="$PT_RUN_CPC",PT_RUN_SPS="$PT_RUN_SPS",PT_RUN_CPS="$PT_RUN_CPS",PT_RUN_SPC="$PT_RUN_SPC",EPOCHS_ROOT_FILE="$EPOCHS_ROOT_FILE",ROIS="$ROIS",CORRECTION="$CORRECTION",ALPHA="$ALPHA",N_PERM_NULL="$N_PERM_NULL",THRESHOLDS="$THRESHOLDS",REQUIRE_ALL="$REQUIRE_ALL",RUN_CONTINUOUS="$RUN_CONTINUOUS",ELECTRODES="$ELECTRODES",EFFECT_MEASURES="$EFFECT_MEASURES",N_SPLITS="$N_SPLITS",N_PERM_CORR="$N_PERM_CORR",MIN_ELEC="$MIN_ELEC",SYNTHETIC_OVERLAP="$SYNTHETIC_OVERLAP",SYNTHETIC_BASE_RATE="$SYNTHETIC_BASE_RATE" \
+    sbatch_power_traces_conjunction_dcc.sh

--- a/docs/stability_flexibility_guide.md
+++ b/docs/stability_flexibility_guide.md
@@ -925,6 +925,28 @@ real permutation cluster mask (slower). Outputs land in
 `results/<tag>/window_<tmin>to<tmax>s_<electrodes>/<CONTRAST_MODE>_<EFFECT_MEASURE>/`
 (`labels.csv`, `conjunction.json`, `correlation.json`, `segregation_summary.png`).
 
+**A1′ / A2 — the same conjunction on `power_traces` electrodes** (§4a, §5.1;
+from `dcc_scripts/stats`). Swaps the electrode definition for the cluster-corrected
+windowed ANOVA and reads it back from a finished `power_traces` run — no ANOVA is
+re-fit, so the count test costs seconds and needs no epoched data:
+```bash
+DATA_SOURCE=synthetic bash submit_power_traces_conjunction_dcc.sh                       # planted overlap
+DATA_SOURCE=synthetic SYNTHETIC_OVERLAP=0.25 bash submit_power_traces_conjunction_dcc.sh  # null -> OR ~ 1
+PT_RUN=/path/to/anova_within_electrode/<conditions_save_name> \
+    bash submit_power_traces_conjunction_dcc.sh                                          # real
+RUN_CONTINUOUS=1 bash submit_power_traces_conjunction_dcc.sh                             # + confound control
+```
+Key knobs: `PT_RUN` (one 4-factor run) **or** `PT_RUN_CPC`/`_SPS`/`_CPS`/`_SPC`
+(four two-factor runs; only CPC and SPS required), `ROIS`, `CORRECTION`
+(`fdr_bh` | `cluster` | `none`), `ALPHA`, `REQUIRE_ALL`, `N_PERM_NULL`,
+`THRESHOLDS`, and — for the control — `RUN_CONTINUOUS`, `EPOCHS_ROOT_FILE`,
+`EFFECT_MEASURES`, `N_SPLITS`, `N_PERM_CORR`. The control's window is taken from
+the run's `run_config.json`, **not** from `WINDOW_TMIN/TMAX` (§5.1). Outputs land in
+`power_traces_conjunction_results/<run_tag>/<CORRECTION>_alpha<ALPHA>/<roi>/`; see
+`dcc_scripts/stats/README.md` for the full table, including why
+`shared − distinct` is *not* a second line of evidence and why sweep rows with an
+empty marginal must be ignored.
+
 **A3 — anatomy** (from `dcc_scripts/stats`):
 ```bash
 DATA_SOURCE=synthetic bash submit_stability_flexibility_anatomy_dcc.sh                        # planted enrichment


### PR DESCRIPTION
`src/analysis/stats/power_traces_conjunction.py` had no launcher: the only reference to it anywhere in dcc_scripts was the segregation entrypoint's optional window alignment. This adds the missing core / entrypoint / sbatch / submit set, matching the layout of the sibling A1/A2 job.

The count test is a pure read of a finished within-electrode windowed-ANOVA run, so it re-fits nothing, needs no epoched data, and can be re-run at several alphas or corrections for free. `general_utils` (and through it mne / ieeg) is imported lazily so that stays true in an environment without the epoched-data stack.

Also included:

* A synthetic mode that fabricates four run directories with a KNOWN planted S/F overlap, so the read -> label -> conjunction path validates in seconds and in both directions (overlap == base rate must return MH OR ~ 1).
* The continuous confound control behind RUN_CONTINUOUS, restricted to the labelled electrodes and windowed from the run's own run_config.json -- a control that covers a different stretch of the epoch is not a control.
* A guard on the threshold sweep. cmh_conjunction builds its strata with shift_zeros=True, so at a cutoff where nothing is selected the 2x2 [[0,0],[0,n]] becomes [[.5,.5],[.5,n+.5]] and reports a large odds ratio with a vanishing p out of a table containing no selected electrodes. Degenerate rows are now named in summary.txt and drawn hollow, outside the trend line.


Claude-Session: https://claude.ai/code/session_01CZRAV47ftVc4ZwC2aEFRDs