### PR TITLE
Select decoding electrodes with the power_traces ANOVA on held-out tr…

### DIFF
--- a/dcc_scripts/decoding/decoding_dcc.py
+++ b/dcc_scripts/decoding/decoding_dcc.py
@@ -88,11 +88,254 @@ from src.analysis.decoding.run_visualization_debug import run_visualization_debu
 from src.analysis.decoding.run_debug_cm_traces import run_debug_cm_traces
 from src.analysis.decoding.run_aggregate_and_plot_time_averaged_cms import run_aggregate_and_plot_time_averaged_cms
 from src.analysis.decoding.run_context_comparisons import run_all_context_comparisons
+
+from src.analysis.decoding.anova_electrode_selection import (
+    decoding_figure_title,
+    electrode_set_counts,
+    electrode_set_counts_for_roi,
+    electrode_set_slug,
+)
+from src.analysis.decoding.run_anova_electrode_selection import (
+    build_anova_selected_electrode_sets,
+)
 '''
-when adding a new condition to decoding - 
+when adding a new condition to decoding -
 1. update config/condition_registry.py
 
 '''
+def run_decoding_for_one_electrode_set(
+    args,
+    rois,
+    condition_names,
+    condition_comparisons,
+    electrodes,
+    subjects_mne_objects,
+    base_save_dir,
+    elec_string_to_add_to_filename,
+    folds_info_str,
+    electrode_set_name=None,
+):
+    """Run the whole bootstrap decoding battery on ONE electrode set.
+
+    Pulled out of ``main`` so the same battery can be run several times over
+    different electrode sets in a single job (LWPC-only, LWPS-only, overlap, …)
+    without re-loading the epochs. With ``electrode_set_name=None`` this is
+    exactly the pre-existing single-run behaviour, writing to the same
+    directory as before.
+
+    Every figure produced here is titled with **what is being decoded** and
+    **which electrodes it was decoded from**, and every filename carries the
+    condition label and the electrode-set slug, because with several sets in
+    flight an untitled accuracy trace is unattributable.
+    """
+    if electrode_set_name:
+        set_slug = electrode_set_slug(electrode_set_name)
+        save_dir = os.path.join(base_save_dir, f"elecset_{set_slug}")
+        elec_string_to_add_to_filename = f"{elec_string_to_add_to_filename}_elecset-{set_slug}"
+        set_label = electrode_set_name
+    else:
+        save_dir = base_save_dir
+        set_label = elec_string_to_add_to_filename
+    os.makedirs(save_dir, exist_ok=True)
+
+    def elec_desc(roi):
+        """Per-ROI electrode-set description for figure titles."""
+        n_elec, n_subs = electrode_set_counts_for_roi(electrodes, roi)
+        return f"{set_label} electrodes (n = {n_elec}, {n_subs} subjects)"
+
+    n_total, n_subs_total = electrode_set_counts(electrodes)
+    print(f"\n{'='*20} DECODING ON ELECTRODE SET '{set_label}' "
+          f"({n_total} electrodes, {n_subs_total} subjects) {'='*20}\n")
+    print(f"  save_dir: {save_dir}")
+    if n_total == 0:
+        print(f"  ✗ Electrode set '{set_label}' is empty; skipping.")
+        return None
+
+    # get the confusion matrix using the downsampled version
+    # add elec and subject info to filename 6/11/25
+    other_string_to_add = (
+        f"{elec_string_to_add_to_filename}_{str(len(args.subjects))}_subjects_{folds_info_str}_ev_{args.explained_variance}"
+    )
+    # append left out subject to file name for leave-one-subject out decoding debugging. Can delete after. 4/28/26.
+    if getattr(args, 'held_out_subject', None):
+        other_string_to_add += f"_loo-{args.held_out_subject}"
+
+    time_window_decoding_results = {}
+
+    print(f"\n{'='*20} STARTING PARALLEL BOOTSTRAPPING ({args.bootstraps} samples across {args.n_jobs} jobs) {'='*20}\n")
+
+    if args.run_visualization_debug: # this needs to be pulled into its own function so that this can be a one liner.
+        run_visualization_debug(args, rois, args.condition_label, electrodes, subjects_mne_objects, save_dir)
+
+    # use joblib to run the bootstrap processing in parallel
+    bootstrap_results_list = Parallel(n_jobs=args.n_jobs, verbose=10, backend='loky')(
+        delayed(process_bootstrap)(
+            bootstrap_idx,
+            subjects_mne_objects,
+            args,
+            rois,
+            condition_names,
+            electrodes,
+            condition_comparisons,
+            save_dir
+        ) for bootstrap_idx in range(args.bootstraps)
+    )
+
+    # reconstruct the main results dictionary from the list returned by the parallel jobs
+    time_window_decoding_results = {i: result['time_window_results'] for i, result in enumerate(bootstrap_results_list) if result is not None}
+    time_averaged_cms_list = [result['time_averaged_cms'] for result in bootstrap_results_list if result]
+
+    ## Extract the 'cats_by_roi' dictionary from the first valid bootstrap result.
+    ## This is necessary to get the correct labels for plotting the confusion matrices.
+    cats_by_roi = {}
+    first_valid_result = next((res for res in bootstrap_results_list if res), None)
+    if first_valid_result:
+        cats_by_roi = first_valid_result.get('cats_by_roi', {})
+
+    # --- Step 1: Aggregate and Plot Time-Averaged CMs ---
+    run_aggregate_and_plot_time_averaged_cms(
+        time_averaged_cms_list, condition_comparisons, rois, cats_by_roi, args, save_dir,
+        electrode_set_desc_fn=elec_desc,
+        filename_suffix=elec_string_to_add_to_filename,
+    )
+
+    if not time_window_decoding_results:
+        print("\n✗ Analysis failed: No bootstrap samples were successfully processed.")
+        return None
+
+    print(f"\n{'-'*20} PARALLEL BOOTSTRAPPING COMPLETE {'='*20}\n")
+
+    # after all bootstraps complete, run pooled statistics
+    all_bootstrap_stats = compute_pooled_bootstrap_statistics(
+        time_window_decoding_results,
+        args.bootstraps,
+        condition_comparisons,
+        rois,
+        percentile=args.percentile,
+        cluster_percentile=args.cluster_percentile,
+        n_cluster_perms=args.n_cluster_perms,
+        random_state=args.random_state,
+        unit_of_analysis=args.unit_of_analysis
+    )
+
+    sub_str = str(len(args.subjects))
+    sub_str_with_ids = "_".join([str(len(args.subjects))] + [s.strip().replace('D00', "").replace('D0', "") for s in args.subjects])
+
+    # The condition label and the electrode set both live in the filename stem:
+    # two runs of this job differ only in what was decoded and from where, so
+    # both have to be recoverable from a file name alone.
+    analysis_params_str = (
+            f"job{args.slurm_job_id}_{args.condition_label}_"
+            f"{sub_str}_subs_{elec_string_to_add_to_filename}_{args.clf_model_str}_"
+            f"{args.bootstraps}boots_{args.n_splits}splits_{args.n_repeats}reps_"
+            f"{args.unit_of_analysis}_unit_ev_{args.explained_variance}"
+        )
+
+    master_results = {
+        'stats': all_bootstrap_stats,
+        'metadata': {
+            'args': vars(args), # Save all arguments from the run
+            'analysis_params_str': analysis_params_str,
+            'electrode_set_name': electrode_set_name,
+            'electrode_set_label': set_label,
+            'electrodes': electrodes,
+            'n_electrodes': n_total,
+        },
+        'comparison_clusters': {} # We will populate this in the loops below
+    }
+
+    # define color and linestyle for plotting true vs shuffle
+    colors = {
+        'true': '#0173B2',  # Blue
+        'shuffle': '#949494'  # Gray
+    }
+
+    linestyles = {
+        'true': '-',
+        'shuffle': '--'
+    }
+
+    # then plot using the pooled statistics
+    for condition_comparison in condition_comparisons.keys():
+        for roi in rois:
+            if roi in all_bootstrap_stats[condition_comparison]:
+                stats = all_bootstrap_stats[condition_comparison][roi]
+                time_window_centers = time_window_decoding_results[0][condition_comparison][roi]['time_window_centers']
+
+                # extract the correct keys based on unit_of_analysis
+                unit = stats['unit_of_analysis']
+
+                plot_accuracies_nature_style(
+                    time_points=time_window_centers,
+                    accuracies_dict={
+                        'true': stats[f'{unit}_true_accs'], # use the full distribution
+                        'shuffle': stats[f'{unit}_shuffle_accs']
+                    },
+                    significant_clusters=stats['significant_clusters'],
+                    window_size=args.window_size,
+                    step_size=args.step_size,
+                    sampling_rate=args.sampling_rate,
+                    comparison_name=f'bootstrap_true_vs_shuffle_{condition_comparison}',
+                    roi=roi,
+                    save_dir=os.path.join(save_dir, f"{condition_comparison}", f"{roi}"),
+                    timestamp=args.timestamp,
+                    p_thresh=args.percentile,
+                    colors=colors,
+                    linestyles=linestyles,
+                    single_column=args.single_column,
+                    show_legend=args.show_legend,
+                    ylim=(0.3, 1.0),
+                    show_chance_level=False, # The pooled shuffle line is the new chance level
+                    title=decoding_figure_title(condition_comparison, roi, elec_desc(roi)),
+                    filename_suffix=analysis_params_str
+                )
+
+    # pooled cm traces for debugging
+    run_debug_cm_traces(
+        time_window_decoding_results=time_window_decoding_results,
+        condition_comparisons=condition_comparisons,
+        rois=rois,
+        cats_by_roi=cats_by_roi,
+        args=args,
+        save_dir=save_dir,
+        analysis_params_str=analysis_params_str,
+        electrode_set_desc_fn=elec_desc,
+    )
+
+    # run context comparisons comparing true vs. true decoding and also true vs. shuffle decoding for lwpc, lwps, etc.
+    run_all_context_comparisons(
+        args=args,
+        time_window_decoding_results=time_window_decoding_results,
+        all_bootstrap_stats=all_bootstrap_stats,
+        master_results=master_results,
+        rois=rois,
+        save_dir=save_dir,
+        analysis_params_str=analysis_params_str,
+        electrode_set_desc_fn=elec_desc,
+    )
+
+    # --- Save all results to a single file ---
+    results_filename = f"{args.timestamp}_MASTER_RESULTS_{analysis_params_str}_{args.condition_label}.pkl"
+
+    results_save_path = os.path.join(save_dir, results_filename)
+
+    # Try to grab time_window_centers and add to metadata
+    try:
+        first_comp = list(time_window_decoding_results[0].keys())[0]
+        first_roi = list(time_window_decoding_results[0][first_comp].keys())[0]
+        twc = time_window_decoding_results[0][first_comp][first_roi]['time_window_centers']
+        master_results['metadata']['time_window_centers'] = twc
+    except Exception as e:
+        print(f"Warning: Could not save time_window_centers to metadata. {e}")
+
+    print(f"\n💾 Saving all statistical results to: {results_save_path}")
+    with open(results_save_path, 'wb') as f:
+        pickle.dump(master_results, f)
+
+    print(f"\n✅ Analysis and saving complete for electrode set '{set_label}'.")
+    return master_results
+
+
 def main(args):
     # Determine LAB_root based on the operating system and environment
     if args.LAB_root is None:
@@ -162,177 +405,83 @@ def main(args):
         elec_string_to_add_to_filename += '_defsplit'
 
     condition_comparisons = get_comparisons(args.condition_label)
- 
-    # get the confusion matrix using the downsampled version
-    # add elec and subject info to filename 6/11/25
-    other_string_to_add = (
-        f"{elec_string_to_add_to_filename}_{str(len(args.subjects))}_subjects_{folds_info_str}_ev_{args.explained_variance}"
-    )
-    # append left out subject to file name for leave-one-subject out decoding debugging. Can delete after. 4/28/26. 
-    if getattr(args, 'held_out_subject', None):
-        other_string_to_add += f"_loo-{args.held_out_subject}"
-            
-    time_window_decoding_results = {}     
-     
-    print(f"\n{'='*20} STARTING PARALLEL BOOTSTRAPPING ({args.bootstraps} samples across {args.n_jobs} jobs) {'='*20}\n")
 
-    if args.run_visualization_debug: # this needs to be pulled into its own function so that this can be a one liner.
-        run_visualization_debug(args, rois, args.condition_label, electrodes, subjects_mne_objects, save_dir)
-        
-    # use joblib to run the bootstrap processing in parallel
-    bootstrap_results_list = Parallel(n_jobs=args.n_jobs, verbose=10, backend='loky')(
-        delayed(process_bootstrap)(
-            bootstrap_idx,
-            subjects_mne_objects,
-            args,
-            rois,
-            condition_names,
-            electrodes,
-            condition_comparisons,
-            save_dir
-        ) for bootstrap_idx in range(args.bootstraps)
-    )
+    # --- Optional: ANOVA-defined electrode sets on a held-out trial partition ---
+    # The same split idea as `electrode_definition_split` above, but the selector
+    # is the power-traces within-electrode windowed ANOVA with permutation
+    # cluster correction rather than a responsiveness t-test — so the electrodes
+    # decoded from are literally the ones the power-trace figures call
+    # significant. Because selection can be run for several condition sets
+    # (e.g. LWPC and LWPS), this yields *several* electrode sets — each label's
+    # electrodes, each label's unique electrodes, their overlap, their union —
+    # and the decoding battery below is run once per requested set.
+    electrode_sets = None
+    if getattr(args, 'anova_electrode_selection', False):
+        if getattr(args, 'electrode_definition_split', False):
+            # Both would split the trials, so the second split would run on a
+            # structure that had already lost its held-out trials — the ANOVA
+            # would be selecting on a fraction of a fraction, and the "70%
+            # decode" in the file name would be a lie. Pick one.
+            raise ValueError(
+                "electrode_definition_split and anova_electrode_selection both "
+                "hold out trials; enable only one. Use "
+                "anova_electrode_selection for cluster-corrected ANOVA electrode "
+                "sets, electrode_definition_split for the responsiveness t-test.")
+        subjects_mne_objects, electrode_sets, selection_report = \
+            build_anova_selected_electrode_sets(
+                args=args,
+                rois=rois,
+                electrodes=electrodes,
+                decode_subjects_mne_objects=subjects_mne_objects,
+                save_dir=save_dir,
+                LAB_root=LAB_root,
+            )
+        # A subject can be dropped entirely by the split (no trials left in some
+        # condition); its electrodes have to go with it or the labelled-array
+        # builder will look up a subject key that no longer exists.
+        electrode_sets = {
+            name: filter_electrode_lists_against_subjects_mne_objects(
+                rois, elecset, subjects_mne_objects)
+            for name, elecset in electrode_sets.items()
+        }
+        elec_string_to_add_to_filename += (
+            f"_anovasel-{selection_report['frac_select']:g}"
+        )
 
-    # reconstruct the main results dictionary from the list returned by the parallel jobs
-    time_window_decoding_results = {i: result['time_window_results'] for i, result in enumerate(bootstrap_results_list) if result is not None}
-    time_averaged_cms_list = [result['time_averaged_cms'] for result in bootstrap_results_list if result]
-
-    ## Extract the 'cats_by_roi' dictionary from the first valid bootstrap result.
-    ## This is necessary to get the correct labels for plotting the confusion matrices.
-    cats_by_roi = {}
-    first_valid_result = next((res for res in bootstrap_results_list if res), None)
-    if first_valid_result:
-        cats_by_roi = first_valid_result.get('cats_by_roi', {})
-
-    # --- Step 1: Aggregate and Plot Time-Averaged CMs ---
-    run_aggregate_and_plot_time_averaged_cms(
-        time_averaged_cms_list, condition_comparisons, rois, cats_by_roi, args, save_dir
-    )
-    
-    if not time_window_decoding_results:
-        print("\n✗ Analysis failed: No bootstrap samples were successfully processed.")
+    # Run the battery once per electrode set. With the option off this is a
+    # single unnamed set — byte-for-byte the previous behaviour.
+    if not electrode_sets:
+        run_decoding_for_one_electrode_set(
+            args=args,
+            rois=rois,
+            condition_names=condition_names,
+            condition_comparisons=condition_comparisons,
+            electrodes=electrodes,
+            subjects_mne_objects=subjects_mne_objects,
+            base_save_dir=save_dir,
+            elec_string_to_add_to_filename=elec_string_to_add_to_filename,
+            folds_info_str=folds_info_str,
+            electrode_set_name=None,
+        )
         return
-    
-    print(f"\n{'-'*20} PARALLEL BOOTSTRAPPING COMPLETE {'='*20}\n")
-    
-    # after all bootstraps complete, run pooled statistics
-    all_bootstrap_stats = compute_pooled_bootstrap_statistics(
-        time_window_decoding_results,
-        args.bootstraps,
-        condition_comparisons,
-        rois,
-        percentile=args.percentile,
-        cluster_percentile=args.cluster_percentile,
-        n_cluster_perms=args.n_cluster_perms,
-        random_state=args.random_state,
-        unit_of_analysis=args.unit_of_analysis
-    )
-    
-    sub_str = str(len(args.subjects))
-    sub_str_with_ids = "_".join([str(len(args.subjects))] + [s.strip().replace('D00', "").replace('D0', "") for s in args.subjects])
-    
-    analysis_params_str = (
-            f"job{args.slurm_job_id}_"
-            f"{sub_str}_subs_{elec_string_to_add_to_filename}_{args.clf_model_str}_" 
-            f"{args.bootstraps}boots_{args.n_splits}splits_{args.n_repeats}reps_"
-            f"{args.unit_of_analysis}_unit_ev_{args.explained_variance}"
-        )   
-                
-    master_results = {
-        'stats': all_bootstrap_stats,
-        'metadata': {
-            'args': vars(args), # Save all arguments from the run
-            'analysis_params_str': analysis_params_str
-        },
-        'comparison_clusters': {} # We will populate this in the loops below
-    }
-       
-    # define color and linestyle for plotting true vs shuffle
-    colors = {
-        'true': '#0173B2',  # Blue
-        'shuffle': '#949494'  # Gray
-    }
-    
-    linestyles = {
-        'true': '-',
-        'shuffle': '--'
-    }  
-    
-    # then plot using the pooled statistics
-    for condition_comparison in condition_comparisons.keys():
-        for roi in rois:
-            if roi in all_bootstrap_stats[condition_comparison]:
-                stats = all_bootstrap_stats[condition_comparison][roi] 
-                time_window_centers = time_window_decoding_results[0][condition_comparison][roi]['time_window_centers']
-                
-                # extract the correct keys based on unit_of_analysis
-                unit = stats['unit_of_analysis']
-                
-                plot_accuracies_nature_style(
-                    time_points=time_window_centers,
-                    accuracies_dict={
-                        'true': stats[f'{unit}_true_accs'], # use the full distribution
-                        'shuffle': stats[f'{unit}_shuffle_accs']
-                    },
-                    significant_clusters=stats['significant_clusters'],
-                    window_size=args.window_size,
-                    step_size=args.step_size,
-                    sampling_rate=args.sampling_rate,
-                    comparison_name=f'bootstrap_true_vs_shuffle_{condition_comparison}',
-                    roi=roi,
-                    save_dir=os.path.join(save_dir, f"{condition_comparison}", f"{roi}"),
-                    timestamp=args.timestamp,
-                    p_thresh=args.percentile,
-                    colors=colors,
-                    linestyles=linestyles,
-                    single_column=args.single_column,
-                    show_legend=args.show_legend,
-                    ylim=(0.3, 1.0),
-                    show_chance_level=False, # The pooled shuffle line is the new chance level 
-                    filename_suffix=analysis_params_str  
-                )    
-                
-    # pooled cm traces for debugging        
-    run_debug_cm_traces(
-        time_window_decoding_results=time_window_decoding_results,
-        condition_comparisons=condition_comparisons,
-        rois=rois,
-        cats_by_roi=cats_by_roi,
-        args=args,
-        save_dir=save_dir,
-        analysis_params_str=analysis_params_str,
-    )
-    
-    # run context comparisons comparing true vs. true decoding and also true vs. shuffle decoding for lwpc, lwps, etc.         
-    run_all_context_comparisons(
-        args=args,
-        time_window_decoding_results=time_window_decoding_results,
-        all_bootstrap_stats=all_bootstrap_stats,
-        master_results=master_results,
-        rois=rois,
-        save_dir=save_dir,
-        analysis_params_str=analysis_params_str,
-    )
-                
-    # --- Save all results to a single file ---
-    results_filename = f"{args.timestamp}_MASTER_RESULTS_{analysis_params_str}_{args.condition_label}.pkl"
-    
-    results_save_path = os.path.join(save_dir, results_filename)
-    
-    # Try to grab time_window_centers and add to metadata
-    try:
-        first_comp = list(time_window_decoding_results[0].keys())[0]
-        first_roi = list(time_window_decoding_results[0][first_comp].keys())[0]
-        twc = time_window_decoding_results[0][first_comp][first_roi]['time_window_centers']
-        master_results['metadata']['time_window_centers'] = twc
-    except Exception as e:
-        print(f"Warning: Could not save time_window_centers to metadata. {e}")
 
-    print(f"\n💾 Saving all statistical results to: {results_save_path}")
-    with open(results_save_path, 'wb') as f:
-        pickle.dump(master_results, f)
+    print(f"\n{'='*20} RUNNING DECODING FOR {len(electrode_sets)} ELECTRODE SETS: "
+          f"{list(electrode_sets)} {'='*20}\n")
+    for set_name, elecset in electrode_sets.items():
+        run_decoding_for_one_electrode_set(
+            args=args,
+            rois=rois,
+            condition_names=condition_names,
+            condition_comparisons=condition_comparisons,
+            electrodes=elecset,
+            subjects_mne_objects=subjects_mne_objects,
+            base_save_dir=save_dir,
+            elec_string_to_add_to_filename=elec_string_to_add_to_filename,
+            folds_info_str=folds_info_str,
+            electrode_set_name=set_name,
+        )
 
-    print("\n✅ Analysis and saving complete.")
+
                   
 if __name__ == "__main__":
     # This block is only executed when someone runs this script directly

--- a/dcc_scripts/decoding/run_decoding_dcc.py
+++ b/dcc_scripts/decoding/run_decoding_dcc.py
@@ -223,6 +223,53 @@ ELECTRODE_DEFINITION_SPLIT_SEED = int(
     os.environ.get('ELECTRODE_DEFINITION_SPLIT_SEED', 0))
 ELECTRODE_DEFINITION_SPLIT_ALPHA = float(
     os.environ.get('ELECTRODE_DEFINITION_SPLIT_ALPHA', 0.05))  # FDR q for the held-out responsiveness selector
+
+# --- ANOVA-defined electrode sets on a held-out trial split ------------------
+# Same disjoint-trial idea as ELECTRODE_DEFINITION_SPLIT above, but the selector
+# is the power-traces within-electrode windowed ANOVA with permutation cluster
+# correction, run once per selection condition set. That gives named electrode
+# sets (lwpc, lwps, lwpc_only, lwps_only, overlap, union) and the decoding
+# battery is run once per set, each into its own subdirectory with the set in
+# every figure title and filename.
+#
+#   ANOVA_ELECTRODE_SELECTION      turn it on
+#   ELECTRODE_SELECTION_FRAC       fraction of trials spent on SELECTION
+#                                  (0.3 -> 30% select / 70% decode)
+#   ELECTRODE_SELECTION_LABELS     comma-separated condition_registry keys whose
+#                                  ANOVA defines the electrodes
+#   ELECTRODE_SELECTION_SETS       comma-separated subset of the available set
+#                                  names; empty -> all of them
+#   ELECTRODE_SELECTION_EFFECT     'interaction' (default; the LWPC/LWPS term),
+#                                  'any', a factor name, or an explicit
+#                                  statsmodels effect name
+#   ELECTRODE_SELECTION_N_PERM     permutations per electrode. This is the cost
+#                                  driver: the ANOVA refits at every window on
+#                                  every permutation. Start at 200.
+ANOVA_ELECTRODE_SELECTION = _env_bool('ANOVA_ELECTRODE_SELECTION', False)
+ELECTRODE_SELECTION_FRAC = float(os.environ.get('ELECTRODE_SELECTION_FRAC', 0.3))
+ELECTRODE_SELECTION_CONDITION_LABELS = (
+    os.environ['ELECTRODE_SELECTION_LABELS'].split(',')
+    if os.environ.get('ELECTRODE_SELECTION_LABELS')
+    else ['stimulus_lwpc_conditions', 'stimulus_lwps_conditions'])
+ELECTRODE_SELECTION_SETS = (
+    os.environ['ELECTRODE_SELECTION_SETS'].split(',')
+    if os.environ.get('ELECTRODE_SELECTION_SETS')
+    else None)   # None -> every set: each label, each *_only, overlap, union
+ELECTRODE_SELECTION_EFFECT = os.environ.get('ELECTRODE_SELECTION_EFFECT', 'interaction')
+ELECTRODE_SELECTION_N_PERM = int(os.environ.get('ELECTRODE_SELECTION_N_PERM', 200))
+ELECTRODE_SELECTION_SEED = int(os.environ.get('ELECTRODE_SELECTION_SEED', 0))
+ELECTRODE_SELECTION_ALPHA = float(os.environ.get('ELECTRODE_SELECTION_ALPHA', 0.05))
+ELECTRODE_SELECTION_USE_FDR = _env_bool('ELECTRODE_SELECTION_USE_FDR', True)
+ELECTRODE_SELECTION_MIN_TRIALS_PER_CELL = int(
+    os.environ.get('ELECTRODE_SELECTION_MIN_TRIALS_PER_CELL', 2))
+# Metadata columns to stratify the trial split on. These must be REAL metadata
+# columns (see parse_event_name): congruency, task_sequence, block_type,
+# incongruent_proportion, switch_proportion, ...
+ELECTRODE_SELECTION_STRATA = (
+    os.environ['ELECTRODE_SELECTION_STRATA'].split(',')
+    if os.environ.get('ELECTRODE_SELECTION_STRATA')
+    else ['congruency', 'task_sequence', 'block_type'])
+
 SAVE_DIR = os.path.join(current_script_dir, 'figs', EPOCHS_ROOT_FILE)
 
 # # # # testing params (comment out)
@@ -295,6 +342,17 @@ def run_analysis():
         electrode_definition_split_strata=ELECTRODE_DEFINITION_SPLIT_STRATA,
         electrode_definition_split_seed=ELECTRODE_DEFINITION_SPLIT_SEED,
         electrode_definition_split_alpha=ELECTRODE_DEFINITION_SPLIT_ALPHA,
+        anova_electrode_selection=ANOVA_ELECTRODE_SELECTION,
+        electrode_selection_frac=ELECTRODE_SELECTION_FRAC,
+        electrode_selection_condition_labels=ELECTRODE_SELECTION_CONDITION_LABELS,
+        electrode_selection_sets=ELECTRODE_SELECTION_SETS,
+        electrode_selection_effect=ELECTRODE_SELECTION_EFFECT,
+        electrode_selection_n_perm=ELECTRODE_SELECTION_N_PERM,
+        electrode_selection_seed=ELECTRODE_SELECTION_SEED,
+        electrode_selection_alpha=ELECTRODE_SELECTION_ALPHA,
+        electrode_selection_use_fdr=ELECTRODE_SELECTION_USE_FDR,
+        electrode_selection_min_trials_per_cell=ELECTRODE_SELECTION_MIN_TRIALS_PER_CELL,
+        electrode_selection_strata=ELECTRODE_SELECTION_STRATA,
         # cluster_tails=CLUSTER_TAILS,
     )
 
@@ -313,6 +371,16 @@ def run_analysis():
              f"seed={ELECTRODE_DEFINITION_SPLIT_SEED}, "
              f"alpha={ELECTRODE_DEFINITION_SPLIT_ALPHA})"
              if ELECTRODE_DEFINITION_SPLIT else ""))
+    print(f"ANOVA electrode selection:     {ANOVA_ELECTRODE_SELECTION}")
+    if ANOVA_ELECTRODE_SELECTION:
+        print(f"  Selection/decode split:    {ELECTRODE_SELECTION_FRAC:.0%} select / "
+              f"{1 - ELECTRODE_SELECTION_FRAC:.0%} decode (seed={ELECTRODE_SELECTION_SEED})")
+        print(f"  Selection condition sets:  {ELECTRODE_SELECTION_CONDITION_LABELS}")
+        print(f"  Electrode sets to decode:  {ELECTRODE_SELECTION_SETS or 'all (labels, *_only, overlap, union)'}")
+        print(f"  ANOVA effect:              {ELECTRODE_SELECTION_EFFECT}")
+        print(f"  ANOVA perms / alpha / FDR: {ELECTRODE_SELECTION_N_PERM} / "
+              f"{ELECTRODE_SELECTION_ALPHA} / {ELECTRODE_SELECTION_USE_FDR}")
+        print(f"  Split strata:              {ELECTRODE_SELECTION_STRATA}")
     print(f"Explained variance: {EXPLAINED_VARIANCE}")
     print(f"Balance method:     {BALANCE_METHOD}")
     print(f"Balance strata:     {BALANCE_STRATA}")

--- a/dcc_scripts/decoding/submit_decoding_with_anova_electrode_selection_dcc.sh
+++ b/dcc_scripts/decoding/submit_decoding_with_anova_electrode_selection_dcc.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Launcher: define electrodes with the POWER-TRACES cluster-corrected ANOVA on a
+# held-out slice of trials, then decode on the disjoint remainder -- once per
+# electrode set, in one job.
+#
+# How this differs from submit_decoding_with_electrode_definition_split_dcc.sh
+# ---------------------------------------------------------------------------
+# That script does the same TRIAL SPLIT, but its selector is a task-
+# responsiveness t-test (window vs. baseline, FDR across channels) and it
+# produces exactly ONE electrode set. This script:
+#
+#   * selects with `run_within_electrode_windowed_anova_cluster_correction` --
+#     the same within-electrode windowed ANOVA + permutation cluster correction
+#     the power-traces figures use -- so "LWPC electrodes" here means exactly
+#     what it means in the power-trace figure;
+#   * runs that selection once per condition set (LWPC and LWPS by default) and
+#     builds the SET ALGEBRA over the results: lwpc, lwps, lwpc_only, lwps_only,
+#     overlap, union;
+#   * runs the decoding battery once per set, each into its own
+#     `elecset_<name>/` subdirectory, with the decoded condition and the
+#     electrode set in every figure title and file name.
+#
+# The comparison it is built for: do LWPC-only and LWPS-only electrodes decode
+# their own contrast but not the other's (segregated subpopulations), or does
+# the overlap set carry both (a shared code)?
+#
+# Splitting on trials is what makes the "define on X, decode X" cells readable
+# at all: the decoder never sees a selection trial. The contrast-level guard
+# still applies on top -- see docs/stability_flexibility_guide.md §3.2 and §8.
+#
+# Usage:
+#   bash submit_decoding_with_anova_electrode_selection_dcc.sh
+#   FRAC_SELECT=0.3 N_PERM=500 bash submit_decoding_with_anova_electrode_selection_dcc.sh
+#   SETS=lwpc_only,lwps_only,overlap bash submit_decoding_with_anova_electrode_selection_dcc.sh
+#   CONDITIONS="stimulus_lwpc_conditions stimulus_lwps_conditions" \
+#       bash submit_decoding_with_anova_electrode_selection_dcc.sh
+
+# ---------------------------------------------------------------------------
+# Conditions to DECODE (space-separated). One job each.
+# ---------------------------------------------------------------------------
+if [ -n "$CONDITIONS" ]; then
+    read -r -a CONDITION_LIST <<< "$CONDITIONS"
+else
+    CONDITION_LIST=(
+        stimulus_lwpc_conditions
+        stimulus_lwps_conditions
+    )
+fi
+
+# ---------------------------------------------------------------------------
+# Selection parameters.
+#   FRAC_SELECT  fraction of each subject's trials spent DEFINING electrodes
+#                (0.3 -> 30% select / 70% decode)
+#   SEL_LABELS   comma-separated condition_registry keys whose ANOVA defines the
+#                electrode sets. Each needs 'anova_factors' in the registry.
+#   SETS         comma-separated electrode sets to decode; empty -> all
+#                (each label, each <label>_only, overlap, union)
+#   EFFECT       'interaction' (the LWPC / LWPS term), 'any', or an explicit
+#                statsmodels effect name
+#   N_PERM       permutations per electrode -- the cost driver
+#   ALPHA        FDR q (or raw cluster p when USE_FDR=false)
+#   STRATA       metadata columns to stratify the trial split on. Must be real
+#                metadata columns: congruency, task_sequence, block_type, ...
+# ---------------------------------------------------------------------------
+FRAC_SELECT=${FRAC_SELECT:-0.3}
+SEL_LABELS=${SEL_LABELS:-stimulus_lwpc_conditions,stimulus_lwps_conditions}
+SETS=${SETS:-}
+EFFECT=${EFFECT:-interaction}
+N_PERM=${N_PERM:-200}
+SEED=${SEED:-0}
+ALPHA=${ALPHA:-0.05}
+USE_FDR=${USE_FDR:-true}
+MIN_TRIALS_PER_CELL=${MIN_TRIALS_PER_CELL:-2}
+STRATA=${STRATA:-congruency,task_sequence,block_type}
+
+mkdir -p out
+
+for COND in "${CONDITION_LIST[@]}"; do
+    echo "Submitting ANOVA-selected decoding: decode=$COND select_on=$SEL_LABELS " \
+         "(frac_select=$FRAC_SELECT, effect=$EFFECT, n_perm=$N_PERM, sets=${SETS:-all})"
+    sbatch --job-name="dec_anovasel_${COND}" \
+        --export=ALL,CONDITION_NAME="$COND",\
+ANOVA_ELECTRODE_SELECTION=true,\
+ELECTRODE_SELECTION_FRAC="$FRAC_SELECT",\
+ELECTRODE_SELECTION_LABELS="$SEL_LABELS",\
+ELECTRODE_SELECTION_SETS="$SETS",\
+ELECTRODE_SELECTION_EFFECT="$EFFECT",\
+ELECTRODE_SELECTION_N_PERM="$N_PERM",\
+ELECTRODE_SELECTION_SEED="$SEED",\
+ELECTRODE_SELECTION_ALPHA="$ALPHA",\
+ELECTRODE_SELECTION_USE_FDR="$USE_FDR",\
+ELECTRODE_SELECTION_MIN_TRIALS_PER_CELL="$MIN_TRIALS_PER_CELL",\
+ELECTRODE_SELECTION_STRATA="$STRATA" \
+        sbatch_decoding_dcc.sh
+done

--- a/docs/analysis_paths.md
+++ b/docs/analysis_paths.md
@@ -121,6 +121,8 @@ src/analysis/
 │   ├── process_bootstrap.py
 │   ├── cross_decoding.py                 # A4: contrasts + circularity table + label-pair glue (§12)
 │   ├── trial_splitting.py                # disjoint def/decode split (circularity control, §13)
+│   ├── anova_electrode_selection.py      # trial-id-keyed split + power_traces ANOVA electrode sets (§13.1)
+│   ├── run_anova_electrode_selection.py  # selection -> decode orchestration for the above
 │   └── run_*.py                          # per-stage orchestration helpers
 │
 ├── pac/         # ANALYSIS PATH: phase-amplitude coupling / connectivity
@@ -580,6 +582,7 @@ Cross-path plotting and anatomy figures:
 | **Stability/flexibility A1–A6** (§12) | `stats/`, `decoding/` | `dcc_scripts/stats/*`, `dcc_scripts/decoding/*cross_decoding*` | long-format single-trial HG | `per_electrode_anova_labels`, `cmh_conjunction`, `roi_group_enrichment_test`, `cross_decode`, `jackknife_onset_difference`, brain–behavior | segregation / anatomy / code / timing / behavior verdicts |
 | **A7 self-check** (§12.7) | `docs/learning_assignments/segregation_bootstrap/` | `pytest` | A1 labels + sensitivities | `bootstrap_conjunction_or`, `segregation_verdict` | OR CI + reconciled verdict |
 | **Def/decode trial split** (§13) | `decoding/trial_splitting.py` | `dcc_scripts/decoding/submit_decoding_with_electrode_definition_split_dcc.sh` | saved HG epochs | `apply_electrode_definition_split` | non-circular decoding accuracies |
+| **ANOVA electrode sets** (§13.1) | `decoding/anova_electrode_selection.py` | `dcc_scripts/decoding/submit_decoding_with_anova_electrode_selection_dcc.sh` | saved HG epochs | `select_electrodes_by_windowed_anova` → `combine_electrode_sets` | per-set (LWPC-only / LWPS-only / overlap / union) decoding accuracies |
 
 ### Where to make common changes
 
@@ -606,6 +609,8 @@ Path-level tests live under `tests/analysis/`:
 |---|---|
 | `decoding/test_decoding.py` | the decoding stack |
 | `decoding/test_trial_splitting.py` | the disjoint split (§13) — 16 tests |
+| `decoding/test_anova_electrode_selection.py` | trial-id split across condition sets, ANOVA-set algebra (§13.1) — 23 tests |
+| `decoding/test_anova_electrode_selection_integration.py` | the real ANOVA selector on planted synthetic effects (marked `slow`) |
 | `decoding/test_cross_decoding_circularity.py` | A4's double-dipping guard |
 | `stats/test_stability_flexibility_anova_labels.py` | A1's four-interaction definition |
 | `stats/test_stability_flexibility_timing.py` | A5, incl. the amplitude-invariance guard |
@@ -1041,9 +1046,82 @@ FRAC_DEF=0.6 SEED=1 ALPHA=0.05 STRATA=congruency,switchType,blockType \
 | `ALPHA` | `0.05` | FDR q-value for the held-out responsiveness selector |
 | `CONDITIONS` | two block-balanced conditions | space-separated condition labels to decode |
 
+> **`STRATA` gotcha.** The default names `switchType` and `blockType` are *not*
+> metadata columns — `parse_event_name` writes `task_sequence` and `block_type`.
+> `strata_key_from_metadata` warns and skips names it cannot find, so the
+> default silently stratifies on `congruency` alone. Pass
+> `STRATA=congruency,task_sequence,block_type` for the intended stratification.
+> (§13.1's launcher already defaults to the correct names.)
+
 **Interpret the output.** Read the `_defsplit` accuracy traces exactly like the
 ordinary decoding output (§7) — the only difference is that the electrode set was
 chosen on trials the decoder never scored, so the accuracy is **not** inflated by
 selection. Expect it to be **lower than the non-split run**; that gap is roughly
 the double-dipping bias the control removes. The job log prints how many
 electrodes survived the held-out selector per ROI.
+
+## 13.1 ANOVA-defined electrode sets (LWPC vs LWPS, unique + overlapping)
+
+Same disjoint-trial idea as §13, **different selector and several output sets**.
+§13 asks "does this electrode respond to the task?" (a responsiveness *t*-test)
+and yields one electrode set. §13.1 asks "does this electrode carry the LWPC /
+LWPS interaction?" using the **power-traces** within-electrode windowed ANOVA
+with permutation cluster correction, run once per selection condition set — so
+the sets it decodes from are exactly the sets the power-trace figures call
+significant, and there is more than one of them.
+
+**The modules.**
+
+| Function | Role |
+|---|---|
+| `collect_subject_trial_strata(structures, strata_cols, id_col)` | Pool every structure's trials per subject, keyed on the stable `metadata['trial_count']` id. |
+| `assign_trial_partitions(sub_trials, frac_select, seed)` | Cut each subject's trials into disjoint `select` / `decode` id sets, stratified. |
+| `apply_trial_partition(structure, partitions, which)` | Restrict a `subjects_mne_objects` structure to one side of the split; drops emptied conditions/subjects. |
+| `select_electrodes_by_windowed_anova(...)` | Run the power-traces ANOVA on the selection partition; keep electrodes with a surviving cluster on the requested effect (default: the highest-order interaction). Writes a normal within-electrode-ANOVA run directory. |
+| `combine_electrode_sets(named_sets, rois, combos)` | Set algebra: `lwpc`, `lwps`, `lwpc_only`, `lwps_only`, `overlap`, `union`. |
+| `build_anova_selected_electrode_sets(...)` | The DCC orchestration: load selection epochs, split, select per label, combine, return the decode partition. |
+
+**Why a trial *id* rather than a positional index.** Selection runs over the LWPC
+2×2 and the LWPS 2×2 while the decode runs over its own condition set — three
+different slicings of the same physical trials. A positional split (§13's) puts
+trial 7 in the selection half of one condition object and the decode half of
+another; keying on `trial_count` makes the two partitions disjoint **sets of
+trials**, whatever conditions each analysis cuts them into.
+
+```bash
+cd dcc_scripts/decoding
+bash submit_decoding_with_anova_electrode_selection_dcc.sh
+FRAC_SELECT=0.3 N_PERM=500 SETS=lwpc_only,lwps_only,overlap \
+    SEL_LABELS=stimulus_lwpc_conditions,stimulus_lwps_conditions \
+    bash submit_decoding_with_anova_electrode_selection_dcc.sh
+```
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `FRAC_SELECT` | `0.3` | fraction of each subject's trials spent **defining** electrodes (rest decodes) |
+| `SEL_LABELS` | `stimulus_lwpc_conditions,stimulus_lwps_conditions` | registry keys whose ANOVA defines the sets (each needs `anova_factors`) |
+| `SETS` | all | subset of `lwpc, lwps, lwpc_only, lwps_only, overlap, union` |
+| `EFFECT` | `interaction` | ANOVA effect to select on; also `any`, a factor name, or an explicit `C(a):C(b)` |
+| `N_PERM` | `200` | permutations per electrode — **the cost driver** |
+| `ALPHA` / `USE_FDR` | `0.05` / `true` | electrode threshold (BH-FDR across electrodes by default) |
+| `STRATA` | `congruency,task_sequence,block_type` | real metadata columns to stratify on |
+
+**Output layout.** One subdirectory per set, and both the decoded condition and
+the electrode set in every title and file name:
+
+```
+figs/<epochs_root_file>/
+├── electrode_selection/
+│   ├── electrode_selection_report.json          # counts + the electrode lists per set
+│   ├── lwpc_congruency_x_incongruentProportion/ # a normal within-elec ANOVA run dir
+│   └── lwps_switchType_x_switchProportion/
+├── elecset_lwpc_only/<comparison>/<roi>/...     # titled "… — lpfc / LWPC-only electrodes (n = …)"
+├── elecset_lwps_only/...
+├── elecset_overlap/...
+└── elecset_union/...
+```
+
+**Interpret the output.** The claim lives in the *pattern across sets*, not in any
+one trace — see `stability_flexibility_guide.md` §8.2 for the three caveats that
+decide whether it is believable (set sizes differ, `overlap` cannot separate a
+shared code from mixed selectivity, and the split costs power on both sides).

--- a/docs/stability_flexibility_guide.md
+++ b/docs/stability_flexibility_guide.md
@@ -867,6 +867,103 @@ Selecting on the *decode contrast itself* (the diagonal) is full double-dipping 
 must use the disjoint split **or** be dropped by §3.2. `electrodes='all'` has no
 selection and no circularity — the currently-safe default for the decoding figures.
 
+### 8.1 Two selectors on the same split — which one, and why
+
+The split above and the one in §8.2 differ **only in the selector**, and the
+choice is not cosmetic:
+
+| | `electrode_definition_split` (§8) | `anova_electrode_selection` (§8.2) |
+|---|---|---|
+| Selector | responsiveness *t*-test, window vs. baseline, FDR over channels (`select_responsive_channels`) | within-electrode windowed ANOVA + permutation cluster correction (`run_within_electrode_windowed_anova_cluster_correction`) — **the power-traces selector** |
+| What it asks | "does this electrode respond to the task at all?" | "does this electrode carry the LWPC / LWPS interaction?" |
+| Relation to the decode | approximately orthogonal | *the same construct*, which is why the trial split is mandatory, not optional |
+| Electrode sets produced | one | one per selection condition set, **plus** unique / overlap / union |
+| Cost | seconds | permutations × windows × electrodes — the expensive part of the job |
+
+The responsiveness selector answers "am I decoding from live tissue"; it cannot
+answer "do different neuronal subpopulations encode stability vs. flexibility
+adaptation", because every set it produces is the same set. That question needs
+electrodes defined *by process*, which is what §8.2 does.
+
+### 8.2 ANOVA-defined electrode sets (LWPC vs LWPS, unique and overlapping)
+
+`src/analysis/decoding/anova_electrode_selection.py` +
+`run_anova_electrode_selection.py`. One job:
+
+1. **Split trials once, on a stable trial id.** `collect_subject_trial_strata`
+   pools every structure's trials per subject keyed on
+   `metadata['trial_count']`, and `assign_trial_partitions` cuts each subject's
+   trials `frac_select` / `1 − frac_select`, stratified. Keying on the id rather
+   than the position is what makes the split hold **across condition sets** —
+   selection runs over the LWPC 2×2 and the LWPS 2×2 while the decode runs over
+   whatever you are decoding, and all three slice the same physical trials
+   differently. A positional split would put trial 7 in the selection half of one
+   and the decode half of another; the old `apply_electrode_definition_split`
+   documents exactly this as a residual leak.
+2. **Select on the selection side, per condition set.**
+   `select_electrodes_by_windowed_anova` runs the power-traces ANOVA and keeps
+   the electrodes with a surviving cluster on the requested effect — by default
+   the **highest-order interaction** (`C(congruency):C(incongruentProportion)`
+   for LWPC, `C(switchType):C(switchProportion)` for LWPS), because the construct
+   is the interaction, not the main effect (§3.1). It writes an ordinary
+   within-electrode-ANOVA run directory (`summary.csv`, per-electrode `.npz`,
+   `run_config.json`), so a selection run is inspectable with the same tooling as
+   a power-traces run.
+3. **Set algebra.** `combine_electrode_sets` builds `lwpc`, `lwps`, `lwpc_only`,
+   `lwps_only`, `overlap`, `union`. `<label>_only` is the electrode-level analogue
+   of the conjunction's `S_only`/`F_only` cells (§5).
+4. **Decode each set** on the disjoint remainder, into `elecset_<name>/`, with
+   the decoded condition **and** the electrode set in every figure title and
+   every file name.
+
+```bash
+# 30% of trials define electrodes, 70% decode; all six sets
+bash submit_decoding_with_anova_electrode_selection_dcc.sh
+FRAC_SELECT=0.3 N_PERM=500 SETS=lwpc_only,lwps_only,overlap \
+    bash submit_decoding_with_anova_electrode_selection_dcc.sh
+```
+
+**What the result means, and what it does not.** The intended read is the
+*pattern across sets*: if LWPC-only electrodes decode congruency-by-block but not
+switch-by-block, and LWPS-only electrodes do the reverse, that is a double
+dissociation over disjoint electrode populations — the multivariate counterpart
+of the conjunction's OR < 1. Three caveats that decide whether it is worth
+believing:
+
+- **The comparison is between sets, not against chance.** Set sizes differ (the
+  stronger effect recruits more electrodes at fixed α — principle §2.3), and
+  decoding accuracy grows with electrode count. A raw "LWPC-only decodes better
+  than LWPS-only" is confounded by n. Compare each set on *its own* two decode
+  cells (matched vs. cross), which is within-set and so n-invariant, and sweep
+  `ELECTRODE_SELECTION_ALPHA` before believing any of it.
+- **`overlap` is where mixed selectivity hides.** An electrode significant for
+  both can carry one shared code or two orthogonal ones; only cross-decoding
+  (§7.1) separates those. `overlap` decoding both contrasts is *not* evidence of
+  a shared code.
+- **The split costs power twice.** The ANOVA sees `frac_select` of the trials, so
+  fewer electrodes clear the threshold (and more are skipped by
+  `min_trials_per_cell` — the run prints the count); the decoder sees the rest,
+  so its accuracy is noisier. 0.3/0.7 is a starting point, not a derived optimum;
+  a null at 0.3 is weak evidence of absence.
+- **A temporally flat effect is the extent test's blind spot.** The permutation
+  null shuffles trial labels within an electrode and reuses that one shuffle at
+  every window, so whatever structure a shuffle accidentally retains appears at
+  *every* window at once. When the true effect is large and constant across the
+  analysis window, the null's cluster-extent distribution piles up at full
+  extent, `extent_threshold` rises to meet it, and the strict
+  `extent > threshold` comparison can reject a real effect. This was reproduced
+  on synthetic data while writing
+  `tests/analysis/decoding/test_anova_electrode_selection_integration.py` (a
+  3 σ planted interaction was missed; 0.8 σ was found). If a selection run
+  returns implausibly few electrodes, check the per-electrode F traces before
+  concluding the effect is not there.
+
+Unit tests: `tests/analysis/decoding/test_anova_electrode_selection.py` (split
+disjointness across condition sets, summary filter, set algebra, naming);
+`..._integration.py` runs the real ANOVA on synthetic data with a planted
+interaction and asserts a main-effect-only electrode does **not** leak into the
+interaction set.
+
 ---
 
 ## 9. How to run everything, and in what order (start here to *do* the analysis)
@@ -942,11 +1039,23 @@ On real data this now also emits `within_block_by_group` — the per-group 2×2 
 the diagonal (define==decode) cell ignored (§3.2). `ALPHA` sets the A1 FDR
 threshold for the four groups; `MIN_GROUP_SIZE` skips groups too small to decode.
 
-**Disjoint def/decode split** (from `dcc_scripts/decoding`):
+**Disjoint def/decode split, responsiveness selector** (from `dcc_scripts/decoding`):
 ```bash
 bash submit_decoding_with_electrode_definition_split_dcc.sh
-FRAC_DEF=0.6 SEED=1 ALPHA=0.05 STRATA=congruency,switchType,blockType \
+FRAC_DEF=0.6 SEED=1 ALPHA=0.05 STRATA=congruency,task_sequence,block_type \
     bash submit_decoding_with_electrode_definition_split_dcc.sh
+```
+> `STRATA` must name **real metadata columns** (`parse_event_name`): `congruency`,
+> `task_sequence`, `block_type`, `incongruent_proportion`, `switch_proportion`.
+> The old default `congruency,switchType,blockType` silently stratified on
+> `congruency` alone — `strata_key_from_metadata` warns and skips names it cannot
+> find.
+
+**Disjoint split, ANOVA electrode sets** (§8.2 — LWPC/LWPS unique + overlap):
+```bash
+bash submit_decoding_with_anova_electrode_selection_dcc.sh
+FRAC_SELECT=0.3 N_PERM=500 SETS=lwpc_only,lwps_only,overlap \
+    bash submit_decoding_with_anova_electrode_selection_dcc.sh
 ```
 
 **A5 — timing** (from `dcc_scripts/stats`):
@@ -1010,6 +1119,10 @@ The `<name>` it writes (e.g. `Stimulus_1sec_preStimulusBase_decFactor_10`) is th
 | Anatomy join | `attach_roi`, `_derive_group` | `src/analysis/stats/stability_flexibility_anatomy.py` |
 | Coverage + enrichment | `build_coverage_matrix`, `roi_group_enrichment_test` | same |
 | Disjoint trial split | `stratified_trial_split`, `apply_electrode_definition_split` | `src/analysis/decoding/trial_splitting.py` |
+| Trial-id-keyed split (holds across condition sets) | `collect_subject_trial_strata`, `assign_trial_partitions`, `apply_trial_partition` | `src/analysis/decoding/anova_electrode_selection.py` |
+| ANOVA-defined electrode sets + set algebra | `select_electrodes_by_windowed_anova`, `combine_electrode_sets` | same |
+| Electrode-set figure titles / file slugs | `decoding_figure_title`, `describe_electrode_set`, `electrode_set_slug` | same |
+| Selection → decode orchestration (DCC) | `build_anova_selected_electrode_sets` | `src/analysis/decoding/run_anova_electrode_selection.py` |
 | power_traces windowed ANOVA (temporal-profile figure) | `run_within_electrode_windowed_anova_cluster_correction`, `load_significant_electrodes` | `src/analysis/power/windowed_anova.py` |
 | Timing | `interaction_time_course`, `onset_50pct_peak`, `jackknife_onset_difference` | `src/analysis/stats/stability_flexibility_timing.py` |
 | Brain–behavior | `subject_level_brain_behavior`, `trialwise_brain_behavior` | `src/analysis/stats/stability_flexibility_brain_behavior.py` |

--- a/src/analysis/decoding/anova_electrode_selection.py
+++ b/src/analysis/decoding/anova_electrode_selection.py
@@ -1,0 +1,697 @@
+"""Electrode selection on a held-out trial partition, via the power_traces ANOVA.
+
+What this adds on top of ``trial_splitting.py``
+-----------------------------------------------
+``trial_splitting.apply_electrode_definition_split`` splits trials and then picks
+electrodes with a **task-responsiveness t-test** — an orthogonal, cheap selector.
+This module keeps the same disjoint-trial logic but swaps in the selector the
+power-traces figures already use: the **within-electrode windowed ANOVA with
+permutation cluster correction**
+(:func:`src.analysis.power.windowed_anova.run_within_electrode_windowed_anova_cluster_correction`).
+That makes the electrode sets fed to the decoder the *same* sets the power
+traces call significant, so "decode from LWPC electrodes" means exactly what the
+LWPC power-trace figure means.
+
+Three pieces, in the order the pipeline uses them:
+
+1. **A trial partition keyed on a stable trial id** (``metadata['trial_count']``),
+   not on each condition object's positional index. This matters here in a way it
+   did not before: selection now runs over a *different condition set* than the
+   decode (LWPC/LWPS conditions to select, whatever you are decoding to decode),
+   and a positional split cannot keep those disjoint — the same physical trial
+   would land in the selection half of one condition object and the decode half
+   of another. Keying on the trial id makes "selection trials" and "decode
+   trials" disjoint **sets of physical trials**, whatever conditions each analysis
+   slices them into. (`collect_subject_trial_strata`, `assign_trial_partitions`,
+   `apply_trial_partition`.)
+2. **Selection** — run the windowed ANOVA on the selection partition only and
+   keep the electrodes with a surviving cluster for the requested effect
+   (by default the highest-order interaction, i.e. the LWPC / LWPS term).
+   (`select_electrodes_by_windowed_anova`.)
+3. **Set algebra** over the resulting groups so the decoder can be pointed at
+   LWPC-only, LWPS-only, the overlap, or the union.
+   (`combine_electrode_sets`.)
+
+The decoder then never sees a selection trial, so a set's decoding accuracy is
+not inflated by the selection — the trial-level guard of guide §8, with the
+selector upgraded to the ANOVA. The contrast-level guard (§3.2's
+"ignore the diagonal") still applies on top: decoding the *same* contrast the
+electrodes were selected on is only interpretable **because** of this split, and
+comparing across sets (LWPC-only vs LWPS-only) is the intended reading.
+"""
+
+from __future__ import annotations
+
+import re
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from src.analysis.decoding.trial_splitting import (
+    stratified_trial_split,
+    strata_key_from_metadata,
+)
+
+# Metadata column holding a per-subject-unique physical trial id. Written by
+# `make_metadata_from_event_names` from the event name's `TrialCount<n>` field.
+DEFAULT_TRIAL_ID_COL = 'trial_count'
+
+# Stratify the split on real metadata columns (see `parse_event_name`). NOTE the
+# older `electrode_definition_split` default was
+# ('congruency', 'switchType', 'blockType'); only `congruency` is an actual
+# metadata column, so the other two were silently dropped with a warning. The
+# parsed names are `task_sequence` (s/r) and `block_type` ((inc_prop, sw_prop)).
+DEFAULT_STRATA_COLS = ('congruency', 'task_sequence', 'block_type')
+
+DEFAULT_EPOCHS_KEY = 'HG_ev1_power_rescaled'
+
+
+# ---------------------------------------------------------------------------
+# 1. Trial partition keyed on a stable trial id
+# ---------------------------------------------------------------------------
+def _is_epochs_like(obj):
+    """Duck-type check for an MNE Epochs-like object (indexable, has times)."""
+    return (obj is not None
+            and hasattr(obj, "get_data")
+            and hasattr(obj, "times")
+            and hasattr(obj, "__getitem__")
+            and hasattr(obj, "__len__"))
+
+
+def _trial_ids(epochs, id_col):
+    """Per-trial ids for an Epochs object, or None if the column is absent."""
+    metadata = getattr(epochs, "metadata", None)
+    if metadata is None or id_col not in metadata.columns:
+        return None
+    return metadata[id_col].to_numpy()
+
+
+def collect_subject_trial_strata(structures, strata_cols=DEFAULT_STRATA_COLS,
+                                 id_col=DEFAULT_TRIAL_ID_COL,
+                                 epochs_key=DEFAULT_EPOCHS_KEY):
+    """Pool every structure's trials per subject into one (ids, strata) table.
+
+    Parameters
+    ----------
+    structures : sequence of dict
+        One or more ``subjects_mne_objects``-shaped dicts
+        (``[sub][condition][epochs_key] -> Epochs``). Pass *every* structure the
+        partition must cover — the decode conditions and each selection
+        condition set — so one partition governs them all.
+    strata_cols : sequence of str
+        Metadata columns to stratify the split on.
+    id_col : str
+        Metadata column holding the stable per-subject trial id.
+
+    Returns
+    -------
+    dict
+        ``{subject: (ids ndarray, strata ndarray)}``, one row per *unique* trial
+        id seen for that subject (first occurrence wins for the stratum key).
+
+    Raises
+    ------
+    ValueError
+        If no epochs object carries ``id_col``. Without a stable id the split
+        cannot be made disjoint across condition sets; use the positional
+        ``electrode_definition_split`` path instead, or attach trial ids.
+    """
+    per_subject = {}
+    saw_id_col = False
+    for structure in structures:
+        for sub, cond_dict in structure.items():
+            for obj_dict in cond_dict.values():
+                epochs = obj_dict.get(epochs_key) if isinstance(obj_dict, dict) else None
+                if not _is_epochs_like(epochs) or len(epochs) == 0:
+                    continue
+                ids = _trial_ids(epochs, id_col)
+                if ids is None:
+                    continue
+                saw_id_col = True
+                metadata = epochs.metadata
+                strata = strata_key_from_metadata(metadata, strata_cols)
+                store = per_subject.setdefault(sub, {})
+                for tid, skey in zip(ids, strata):
+                    store.setdefault(tid, skey)
+
+    if not saw_id_col:
+        raise ValueError(
+            f"No epochs object carries a '{id_col}' metadata column, so trials "
+            f"cannot be split disjointly across condition sets. Attach trial ids "
+            f"(make_metadata_from_event_names writes 'trial_count') or use the "
+            f"positional electrode_definition_split path."
+        )
+
+    out = {}
+    for sub, store in per_subject.items():
+        ids = np.array(list(store.keys()))
+        strata = np.array([store[t] for t in ids], dtype=object)
+        order = np.argsort(ids)   # deterministic order regardless of dict order
+        out[sub] = (ids[order], strata[order])
+    return out
+
+
+def assign_trial_partitions(sub_trials, frac_select=0.3, seed=0):
+    """Split each subject's trial ids into a selection set and a decode set.
+
+    Parameters
+    ----------
+    sub_trials : dict
+        Output of :func:`collect_subject_trial_strata`.
+    frac_select : float
+        Fraction of each stratum assigned to **electrode selection**; the rest
+        goes to decoding (e.g. 0.3 → 30% select / 70% decode).
+    seed : int
+        Base RNG seed. Offset per subject so subjects do not share a shuffle.
+
+    Returns
+    -------
+    dict
+        ``{subject: {'select': set_of_ids, 'decode': set_of_ids}}`` — disjoint,
+        and together covering every id.
+    """
+    partitions = {}
+    for sub in sorted(sub_trials):
+        ids, strata = sub_trials[sub]
+        sub_seed = seed + (abs(hash(sub)) % 100_000)
+        idx_sel, idx_dec = stratified_trial_split(strata, frac_def=frac_select,
+                                                  seed=sub_seed)
+        partitions[sub] = {'select': set(ids[idx_sel].tolist()),
+                           'decode': set(ids[idx_dec].tolist())}
+    return partitions
+
+
+def apply_trial_partition(structure, partitions, which='decode',
+                          id_col=DEFAULT_TRIAL_ID_COL, verbose=True):
+    """Restrict every Epochs object in ``structure`` to one side of the split.
+
+    Objects in the same ``[sub][condition]`` dict that are trial-aligned with the
+    reference epochs (same length) are sliced with the same indices, so any
+    downstream signal stays aligned; everything else (Evoked averages, scalars)
+    is carried through untouched. Conditions left with zero trials are dropped,
+    as are subjects left with no conditions — the same cleanup
+    ``create_subjects_mne_objects_dict`` does, so downstream code sees a
+    structure of the shape it already expects.
+
+    Parameters
+    ----------
+    structure : dict
+        ``[sub][condition][key] -> Epochs``.
+    partitions : dict
+        Output of :func:`assign_trial_partitions`.
+    which : {'select', 'decode'}
+    """
+    if which not in ('select', 'decode'):
+        raise ValueError(f"which must be 'select' or 'decode', got {which!r}")
+
+    out = {}
+    for sub, cond_dict in structure.items():
+        keep_ids = partitions.get(sub, {}).get(which)
+        if keep_ids is None:
+            if verbose:
+                print(f"  [trial-split] {sub}: no partition assigned; dropping.")
+            continue
+        sub_out = {}
+        for cond, obj_dict in cond_dict.items():
+            ref = None
+            for val in obj_dict.values():
+                if _is_epochs_like(val) and _trial_ids(val, id_col) is not None:
+                    ref = val
+                    break
+            if ref is None:
+                # Nothing sliceable / identifiable — carry the condition through
+                # untouched rather than silently dropping data.
+                sub_out[cond] = obj_dict
+                continue
+            n = len(ref)
+            ids = _trial_ids(ref, id_col)
+            idx = np.flatnonzero(np.isin(ids, list(keep_ids)))
+            if idx.size == 0:
+                if verbose:
+                    print(f"  [trial-split] {sub}/{cond}: 0 trials on the "
+                          f"'{which}' side; dropping this condition.")
+                continue
+            new_obj = {}
+            for key, val in obj_dict.items():
+                if _is_epochs_like(val) and len(val) == n:
+                    new_obj[key] = val[idx]
+                else:
+                    new_obj[key] = val
+            sub_out[cond] = new_obj
+        if sub_out:
+            out[sub] = sub_out
+        elif verbose:
+            print(f"  [trial-split] {sub}: no conditions survived the "
+                  f"'{which}' partition; dropping subject.")
+    return out
+
+
+def partition_trial_counts(structure, epochs_key=DEFAULT_EPOCHS_KEY):
+    """``{subject: total trials}`` across conditions — for split sanity prints."""
+    counts = {}
+    for sub, cond_dict in structure.items():
+        total = 0
+        for obj_dict in cond_dict.values():
+            epochs = obj_dict.get(epochs_key) if isinstance(obj_dict, dict) else None
+            if _is_epochs_like(epochs):
+                total += len(epochs)
+        counts[sub] = total
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# 2. Selection: the power_traces cluster-corrected windowed ANOVA
+# ---------------------------------------------------------------------------
+def interaction_effect_name(anova_factors):
+    """statsmodels name of the highest-order interaction over ``anova_factors``.
+
+    ``['congruency', 'incongruentProportion']`` →
+    ``'C(congruency):C(incongruentProportion)'`` — the LWPC term. This is the
+    default selector because the construct under test *is* the interaction (guide
+    §3.1): a congruency main effect means "responds to conflict", not "implements
+    the list-wide adjustment".
+    """
+    return ':'.join(f'C({f})' for f in anova_factors)
+
+
+def resolve_effect(effect, anova_factors):
+    """Map an ``effect`` request onto a concrete effect name (or None for 'any').
+
+    ``'interaction'`` → the highest-order interaction; ``'any'`` → None (an
+    electrode counts if *any* effect survives); a bare factor name (e.g.
+    ``'congruency'``) → ``'C(congruency)'``; anything else is passed through
+    verbatim so an explicit statsmodels name always works.
+    """
+    if effect in (None, 'any'):
+        return None
+    if effect == 'interaction':
+        if not anova_factors or len(anova_factors) < 2:
+            raise ValueError(
+                f"effect='interaction' needs >=2 anova_factors, got {anova_factors}")
+        return interaction_effect_name(anova_factors)
+    if anova_factors and effect in anova_factors:
+        return f'C({effect})'
+    return effect
+
+
+def safe_effect_slug(effect_name):
+    """Filename-safe form of a statsmodels effect name (matches windowed_anova)."""
+    if effect_name is None:
+        return 'any_effect'
+    return effect_name.replace(':', '_x_').replace('C(', '').replace(')', '')
+
+
+def _usable_subjects(structure, condition_names, subjects, epochs_key,
+                     min_trials=1, verbose=True):
+    """Subjects that have every ANOVA condition with >= ``min_trials`` trials.
+
+    ``process_windowed_data_for_anova`` indexes ``[sub][cond][epochs_key]``
+    unguarded, so a subject missing one cell of the design would raise. Dropping
+    those subjects here (loudly) is also statistically right: a subject missing a
+    cell cannot contribute to a factorial ANOVA anyway.
+    """
+    usable = []
+    for sub in subjects:
+        cond_dict = structure.get(sub)
+        if not cond_dict:
+            if verbose:
+                print(f"  [anova-select] {sub}: no data; excluded.")
+            continue
+        missing = []
+        for cond in condition_names:
+            epochs = (cond_dict.get(cond) or {}).get(epochs_key)
+            if not _is_epochs_like(epochs) or len(epochs) < min_trials:
+                missing.append(cond)
+        if missing:
+            if verbose:
+                print(f"  [anova-select] {sub}: missing/empty conditions "
+                      f"{missing}; excluded from the ANOVA.")
+            continue
+        usable.append(sub)
+    return usable
+
+
+def _first_times(structure, epochs_key=DEFAULT_EPOCHS_KEY):
+    for cond_dict in structure.values():
+        for obj_dict in cond_dict.values():
+            epochs = obj_dict.get(epochs_key) if isinstance(obj_dict, dict) else None
+            if _is_epochs_like(epochs) and len(epochs) > 0:
+                return np.asarray(epochs.times)
+    return None
+
+
+def significant_electrodes_from_summary(summary_df, rois, candidate_electrodes,
+                                        effect_name=None, use_fdr=True,
+                                        alpha=0.05):
+    """Filter a within-electrode ANOVA ``summary.csv`` frame to an electrode set.
+
+    Parameters
+    ----------
+    summary_df : pandas.DataFrame
+        Tidy summary from
+        ``run_within_electrode_windowed_anova_cluster_correction`` — one row per
+        (subject, electrode, roi, effect, cluster).
+    effect_name : str or None
+        Keep only this effect; None keeps an electrode if *any* effect survives.
+    use_fdr : bool
+        Use the BH-FDR-across-electrodes decision (``sig_after_fdr``) rather than
+        the raw cluster p. FDR is the right family here: one test per electrode
+        (guide §2.4).
+    alpha : float
+        Threshold for the raw-p route when ``use_fdr`` is False.
+
+    Returns
+    -------
+    dict
+        ``{roi: {subject: [electrode, ...]}}``, intersected with
+        ``candidate_electrodes`` so the ROI membership the caller established is
+        never widened by the selection.
+    """
+    selected = {roi: {} for roi in rois}
+    if summary_df is None or summary_df.empty:
+        return selected
+
+    df = summary_df
+    if effect_name is not None:
+        df = df[df['effect'] == effect_name]
+    if use_fdr and 'sig_after_fdr' in df.columns:
+        df = df[df['sig_after_fdr'].astype(bool)]
+    else:
+        df = df[df['cluster_p_value'].fillna(1.0) < alpha]
+
+    sig_pairs = set(map(tuple, df[['subject', 'electrode']].drop_duplicates().to_numpy()))
+    for roi in rois:
+        for sub, chans in candidate_electrodes.get(roi, {}).items():
+            selected[roi][sub] = [c for c in chans if (sub, c) in sig_pairs]
+    return selected
+
+
+def select_electrodes_by_windowed_anova(
+    selection_mne_objects,
+    electrodes,
+    rois,
+    subjects,
+    conditions_obj,
+    anova_factors,
+    *,
+    effect='interaction',
+    window_size=64,
+    step_size=16,
+    sampling_rate=256,
+    n_perm=200,
+    percentile=95,
+    cluster_percentile=95,
+    min_trials_per_cell=2,
+    split_clusters_by_sign=True,
+    use_fdr=True,
+    alpha=0.05,
+    seed=42,
+    n_jobs=-1,
+    verbose=True,
+    save_dir=None,
+    run_label=None,
+    epochs_key=DEFAULT_EPOCHS_KEY,
+):
+    """Run the power-traces within-electrode ANOVA and return the significant set.
+
+    This is the *same* call the power-traces job makes
+    (``process_windowed_data_for_anova`` →
+    ``run_within_electrode_windowed_anova_cluster_correction``), pointed at the
+    selection partition instead of all trials. Passing ``save_dir``/``run_label``
+    makes it write the ordinary run directory (``summary.csv``, per-electrode
+    ``.npz``, ``sig_electrodes_*.json``, ``run_config.json``), so a selection run
+    is inspectable with the same tooling as a power-traces run and can be
+    re-loaded later with ``load_significant_electrodes``.
+
+    Returns
+    -------
+    dict
+        ``{'selected': {roi: {sub: [chan, ...]}}, 'summary_df': DataFrame,
+        'effect': str or None, 'skipped': list, 'window_centers': ndarray,
+        'subjects_used': list}``
+    """
+    # Imported lazily: `windowed_anova` pulls in `ieeg` through `general_utils`,
+    # which is not importable off-cluster. Keeping it here means this module's
+    # pure helpers (and their tests) stay importable anywhere.
+    from src.analysis.power.windowed_anova import (
+        process_windowed_data_for_anova,
+        run_within_electrode_windowed_anova_cluster_correction,
+    )
+
+    condition_names = list(conditions_obj.keys())
+    subjects_used = _usable_subjects(selection_mne_objects, condition_names,
+                                     subjects, epochs_key,
+                                     min_trials=min_trials_per_cell,
+                                     verbose=verbose)
+    effect_name = resolve_effect(effect, anova_factors)
+
+    empty = {roi: {sub: [] for sub in electrodes.get(roi, {})} for roi in rois}
+    if not subjects_used:
+        warnings.warn("select_electrodes_by_windowed_anova: no subject has every "
+                      "ANOVA condition on the selection partition; selecting no "
+                      "electrodes.", stacklevel=2)
+        return {'selected': empty, 'summary_df': pd.DataFrame(),
+                'effect': effect_name, 'skipped': [], 'window_centers': None,
+                'subjects_used': []}
+
+    # Restrict the candidate electrodes to the usable subjects so the ANOVA's
+    # electrode list and its data list stay index-aligned (the windowed-data
+    # builder and the dataframe builder skip subjects in lockstep).
+    candidates = {roi: {sub: list(chans)
+                        for sub, chans in electrodes.get(roi, {}).items()
+                        if sub in subjects_used and chans}
+                  for roi in rois}
+
+    times = _first_times(selection_mne_objects, epochs_key)
+    if times is None:
+        raise RuntimeError("No usable epochs found on the selection partition.")
+
+    if verbose:
+        n_cand = sum(len(v) for d in candidates.values() for v in d.values())
+        print(f"[anova-select] {len(subjects_used)} subjects, {n_cand} candidate "
+              f"electrodes, effect={effect_name or 'any'}, n_perm={n_perm}")
+
+    windowed_data = process_windowed_data_for_anova(
+        selection_mne_objects, condition_names, rois, subjects_used,
+        candidates, window_size=window_size, step_size=step_size,
+        sampling_rate=sampling_rate,
+    )
+
+    (_results, window_centers, summary_df, skipped) = \
+        run_within_electrode_windowed_anova_cluster_correction(
+            windowed_data, conditions_obj, anova_factors, rois, subjects_used,
+            electrodes_per_subject_roi=candidates,
+            times=times,
+            window_size=window_size, step_size=step_size,
+            sampling_rate=sampling_rate,
+            n_perm=n_perm,
+            percentile=percentile,
+            cluster_percentile=cluster_percentile,
+            min_trials_per_cell=min_trials_per_cell,
+            split_clusters_by_sign=split_clusters_by_sign,
+            seed=seed, n_jobs=n_jobs, verbose=verbose,
+            save_dir=save_dir, run_label=run_label,
+        )
+
+    selected = significant_electrodes_from_summary(
+        summary_df, rois, candidates, effect_name=effect_name,
+        use_fdr=use_fdr, alpha=alpha,
+    )
+    # Re-add the excluded subjects with empty lists so every downstream consumer
+    # sees the same subject keys it started with.
+    for roi in rois:
+        for sub in electrodes.get(roi, {}):
+            selected[roi].setdefault(sub, [])
+
+    if verbose:
+        n_sel, n_subs = electrode_set_counts(selected)
+        print(f"[anova-select] {n_sel} electrodes across {n_subs} subjects "
+              f"survived ({'FDR q' if use_fdr else 'cluster p'} < {alpha})")
+        if skipped:
+            print(f"[anova-select] {len(skipped)} electrodes skipped "
+                  f"(min_trials_per_cell={min_trials_per_cell}) — expected to "
+                  f"rise as the selection fraction shrinks.")
+
+    return {'selected': selected, 'summary_df': summary_df,
+            'effect': effect_name, 'skipped': skipped,
+            'window_centers': window_centers, 'subjects_used': subjects_used}
+
+
+# ---------------------------------------------------------------------------
+# 3. Set algebra over the selected groups
+# ---------------------------------------------------------------------------
+def _as_pairs(elecset, rois):
+    """``{roi: {(sub, chan), ...}}`` view of a ``{roi: {sub: [chan]}}`` set."""
+    return {roi: {(sub, c) for sub, chans in elecset.get(roi, {}).items()
+                  for c in chans}
+            for roi in rois}
+
+
+def _all_subjects(named_sets, rois):
+    subs = {roi: [] for roi in rois}
+    for elecset in named_sets.values():
+        for roi in rois:
+            for sub in elecset.get(roi, {}):
+                if sub not in subs[roi]:
+                    subs[roi].append(sub)
+    return subs
+
+
+def available_combo_names(labels):
+    """Combo names produced by :func:`combine_electrode_sets` for ``labels``."""
+    names = list(labels)
+    if len(labels) >= 2:
+        names += [f'{lab}_only' for lab in labels] + ['overlap', 'union']
+    return names
+
+
+def combine_electrode_sets(named_sets, rois, combos=None):
+    """Build unique / overlapping / union electrode sets from named sets.
+
+    Parameters
+    ----------
+    named_sets : dict
+        ``{label: {roi: {subject: [chan, ...]}}}`` — e.g.
+        ``{'lwpc': ..., 'lwps': ...}``.
+    rois : sequence of str
+    combos : sequence of str or None
+        Which combinations to build. ``None`` builds all of
+        :func:`available_combo_names`. Recognized names:
+
+        =============  ==========================================================
+        ``<label>``    every electrode significant for that label
+        ``<label>_only``  significant for that label and **no** other label
+        ``overlap``    significant for **every** label (the shared population)
+        ``union``      significant for **at least one** label
+        =============  ==========================================================
+
+    Returns
+    -------
+    dict
+        ``{combo_name: {roi: {subject: [chan, ...]}}}``, channel order preserved
+        from the first label that contributed the electrode so a set is
+        reproducible run to run.
+
+    Notes
+    -----
+    ``<label>_only`` is the electrode-level analogue of the conjunction's
+    ``S_only`` / ``F_only`` cells (guide §5), and the *point* of the comparison:
+    if LWPC-only and LWPS-only electrodes each decode their own contrast but not
+    the other's, that is positive evidence for segregated subpopulations in a way
+    a single pooled decode cannot give. ``overlap`` is the mixed-selectivity
+    control — a shared code and orthogonal codes on the same electrodes look the
+    same in a count, but not in a decode.
+    """
+    labels = list(named_sets.keys())
+    if combos is None:
+        combos = available_combo_names(labels)
+
+    pairs = {lab: _as_pairs(named_sets[lab], rois) for lab in labels}
+    subs_by_roi = _all_subjects(named_sets, rois)
+
+    def _build(pred):
+        out = {}
+        for roi in rois:
+            all_pairs = set().union(*[pairs[lab][roi] for lab in labels]) if labels else set()
+            keep = {p for p in all_pairs if pred(p, roi)}
+            by_sub = {sub: [] for sub in subs_by_roi[roi]}
+            # Preserve each label's channel ordering, first label wins.
+            for lab in labels:
+                for sub, chans in named_sets[lab].get(roi, {}).items():
+                    for c in chans:
+                        if (sub, c) in keep and c not in by_sub.setdefault(sub, []):
+                            by_sub[sub].append(c)
+            out[roi] = by_sub
+        return out
+
+    result = {}
+    for name in combos:
+        if name in labels:
+            result[name] = _build(lambda p, roi, lab=name: p in pairs[lab][roi])
+        elif name.endswith('_only') and name[:-len('_only')] in labels:
+            lab = name[:-len('_only')]
+            others = [o for o in labels if o != lab]
+            result[name] = _build(
+                lambda p, roi, lab=lab, others=others:
+                p in pairs[lab][roi] and not any(p in pairs[o][roi] for o in others))
+        elif name == 'overlap':
+            result[name] = _build(
+                lambda p, roi: all(p in pairs[lab][roi] for lab in labels))
+        elif name == 'union':
+            result[name] = _build(
+                lambda p, roi: any(p in pairs[lab][roi] for lab in labels))
+        else:
+            raise ValueError(
+                f"Unknown electrode-set combination {name!r}. "
+                f"Available: {available_combo_names(labels)}")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 4. Naming — so every figure says which electrodes it was decoded from
+# ---------------------------------------------------------------------------
+def electrode_set_counts(elecset):
+    """``(n_electrodes, n_subjects_contributing)`` for a ``{roi: {sub: [chan]}}``."""
+    n_elec, subs = 0, set()
+    for by_sub in elecset.values():
+        for sub, chans in by_sub.items():
+            n_elec += len(chans)
+            if chans:
+                subs.add(sub)
+    return n_elec, len(subs)
+
+
+def electrode_set_counts_for_roi(elecset, roi):
+    """``(n_electrodes, n_subjects)`` restricted to one ROI."""
+    by_sub = elecset.get(roi, {})
+    n_elec = sum(len(c) for c in by_sub.values())
+    n_subs = sum(1 for c in by_sub.values() if c)
+    return n_elec, n_subs
+
+
+def electrode_set_slug(name):
+    """Filename-safe slug for an electrode-set name."""
+    return re.sub(r'[^0-9A-Za-z]+', '_', str(name)).strip('_')
+
+
+_PRETTY = {
+    'overlap': 'overlap',
+    'union': 'union',
+}
+
+
+def pretty_electrode_set(name):
+    """Human-readable electrode-set name for a figure title."""
+    if name in _PRETTY:
+        return _PRETTY[name]
+    if name.endswith('_only'):
+        return f"{name[:-len('_only')].upper()}-only"
+    return name.replace('_', ' ').upper() if len(name) <= 8 else name.replace('_', ' ')
+
+
+def describe_electrode_set(name, elecset, roi=None):
+    """``'LWPC-only electrodes (n = 42, 11 subjects)'`` for titles/prints."""
+    if roi is None:
+        n_elec, n_subs = electrode_set_counts(elecset)
+    else:
+        n_elec, n_subs = electrode_set_counts_for_roi(elecset, roi)
+    return (f"{pretty_electrode_set(name)} electrodes "
+            f"(n = {n_elec}, {n_subs} subjects)")
+
+
+def decoding_figure_title(condition_comparison, roi, electrode_set_desc=None,
+                          extra=None):
+    """Two-line title: what is being decoded, then from which electrodes.
+
+    The second line is the whole point of this module — a decoding figure that
+    does not say which electrode set it came from is unreadable once several
+    sets are in play.
+    """
+    line1 = f"{str(condition_comparison).replace('_', ' ')} — {roi}"
+    parts = [line1]
+    if electrode_set_desc:
+        parts.append(str(electrode_set_desc))
+    if extra:
+        parts.append(str(extra))
+    return "\n".join(parts)

--- a/src/analysis/decoding/context_comparison.py
+++ b/src/analysis/decoding/context_comparison.py
@@ -22,11 +22,12 @@ def run_context_comparison_analysis(
     args,
     rois,
     save_dir,
-    analysis_params_str
+    analysis_params_str,
+    electrode_set_desc_fn=None
 ):
     """
     Run comparison analysis between two conditions with pooled shuffle distribution.
-    
+
     Parameters
     ----------
     condition_name : str
@@ -61,8 +62,12 @@ def run_context_comparison_analysis(
         Base save directory
     analysis_params_str : str
         String describing analysis parameters for filenames
+    electrode_set_desc_fn : callable(roi) -> str, optional
+        One-line description of the electrode set being decoded from, added to
+        every figure title so the electrode set is never implicit.
     """
-    
+    from .anova_electrode_selection import decoding_figure_title
+
     print(f"\n--- Running {condition_name} Comparison Statistics ({condition_comparison_1} vs {condition_comparison_2}) using '{args.unit_of_analysis}' as unit of analysis ---")
     
     for roi in rois:
@@ -160,6 +165,10 @@ def run_context_comparison_analysis(
             ylim=(0.3, 0.8),
             ylabel=ylabel,
             show_chance_level=False,
+            title=decoding_figure_title(
+                f"{condition_name}: {condition_comparison_1} vs {condition_comparison_2}",
+                roi,
+                electrode_set_desc_fn(roi) if electrode_set_desc_fn else None),
             filename_suffix=analysis_params_str,
             show_sig_legend=True,
             sig_bar_base_position=0.72,
@@ -201,6 +210,11 @@ def run_context_comparison_analysis(
             ylabel=f"Accuracy Difference ({condition_comparison_1.replace('_', ' ')} - {condition_comparison_2.replace('_', ' ')})",
             show_chance_level=True,
             chance_level=0,
+            title=decoding_figure_title(
+                f"{condition_name} accuracy difference: "
+                f"{condition_comparison_1} − {condition_comparison_2}",
+                roi,
+                electrode_set_desc_fn(roi) if electrode_set_desc_fn else None),
             filename_suffix=analysis_params_str + "_ACC_DIFFERENCE",
             show_sig_legend=False,
             sig_bar_base_position=diff_ylim[1] * 0.8,
@@ -222,12 +236,18 @@ def plot_cross_block_overlay(
     args,
     rois,
     save_dir,
-    analysis_params_str
+    analysis_params_str,
+    electrode_set_desc_fn=None
 ):
     """
     Overlay decoding accuracy from multiple blocks on a single plot,
     and store pooled shuffle data in master_results for later re-plotting.
+
+    ``electrode_set_desc_fn`` : callable(roi) -> str, optional -- electrode-set
+    description for the figure title.
     """
+    from .anova_electrode_selection import decoding_figure_title
+
     print(f"\n📊 Generating cross-block {variable_name.upper()} overlay plots...")
 
     # Pool shuffle distributions across bootstraps
@@ -286,6 +306,9 @@ def plot_cross_block_overlay(
             show_chance_level=False,
             show_legend=True,
             ylabel=ylabel,
+            title=decoding_figure_title(
+                f"{variable_name} decoding across blocks", roi,
+                electrode_set_desc_fn(roi) if electrode_set_desc_fn else None),
             filename_suffix=analysis_params_str,
             single_column=False,
         )

--- a/src/analysis/decoding/run_aggregate_and_plot_time_averaged_cms.py
+++ b/src/analysis/decoding/run_aggregate_and_plot_time_averaged_cms.py
@@ -25,8 +25,19 @@ def run_aggregate_and_plot_time_averaged_cms(
     cats_by_roi,
     args,
     save_dir,
+    electrode_set_desc_fn=None,
+    filename_suffix="",
 ):
-    
+    """Aggregate and plot the time-averaged confusion matrices.
+
+    ``electrode_set_desc_fn`` : callable(roi) -> str, optional
+        Returns a one-line description of the electrode set these CMs were
+        decoded from; appended to the title so a figure is attributable when
+        several electrode sets are run in one job.
+    ``filename_suffix`` : str, optional
+        Appended to the filename for the same reason.
+    """
+
     # --- Step 1: Aggregate and Plot Time-Averaged CMs ---
     print("\n📊 Aggregating and plotting time-averaged confusion matrices...")
     for condition_comparison in condition_comparisons.keys():
@@ -58,10 +69,16 @@ def run_aggregate_and_plot_time_averaged_cms(
             fig, ax = plt.subplots()
             disp = ConfusionMatrixDisplay(confusion_matrix=normalized_cm, display_labels=display_labels)
             disp.plot(ax=ax, im_kw={"vmin": 0, "vmax": 1}, colorbar=True)
-            ax.set_title(f'{roi} - {condition_comparison}\n(Counts summed across {args.bootstraps} bootstraps)')
+            title_lines = [f'{roi} - {condition_comparison}']
+            if electrode_set_desc_fn is not None:
+                title_lines.append(electrode_set_desc_fn(roi))
+            title_lines.append(f'(Counts summed across {args.bootstraps} bootstraps)')
+            ax.set_title("\n".join(title_lines), fontsize=9)
 
+            suffix = f'_{filename_suffix}' if filename_suffix else ''
             filename = (
-                f'{args.timestamp}_{roi}_{condition_comparison}_SUMMED_{args.bootstraps}boots_ev_{args.explained_variance}'
+                f'{args.timestamp}_{args.condition_label}_{roi}_{condition_comparison}_SUMMED_'
+                f'{args.bootstraps}boots_ev_{args.explained_variance}{suffix}_'
                 f'time_averaged_confusion_matrix.png'
             )
             plot_save_path = os.path.join(save_dir, condition_comparison, roi)

--- a/src/analysis/decoding/run_anova_electrode_selection.py
+++ b/src/analysis/decoding/run_anova_electrode_selection.py
@@ -1,0 +1,261 @@
+"""Orchestration: held-out trial split → ANOVA electrode sets → decode partition.
+
+This is the glue `decoding_dcc.py` calls when
+``args.anova_electrode_selection`` is on. It is deliberately thin — every piece
+of logic it strings together lives in
+:mod:`src.analysis.decoding.anova_electrode_selection` (split, selection, set
+algebra) or in :mod:`src.analysis.power.windowed_anova` (the ANOVA itself), so
+this file can be read as the recipe:
+
+1. Load a *separate* epochs structure per selection condition set (e.g. the four
+   LWPC cells, the four LWPS cells). Selection needs the 2×2 the ANOVA's
+   interaction term is defined over, which is generally **not** the condition
+   set being decoded.
+2. Build one trial partition per subject over the union of every structure's
+   trials, keyed on the stable trial id, and split it ``frac_select`` /
+   ``1 - frac_select``.
+3. Run the power-traces within-electrode windowed ANOVA on the *selection* side
+   of that partition, once per condition set, and keep the electrodes with a
+   surviving cluster on the requested effect.
+4. Hand back the *decode* side of the partition plus the electrode sets
+   (each label, each label's unique electrodes, the overlap, the union).
+
+Why a separate load per selection label rather than reusing the decode epochs:
+the ANOVA is fit on condition cells, and the decode conditions may be a
+different (often coarser or block-balanced) partition of the same trials. Going
+back to the epochs file for each selection condition set is the only way to get
+the exact factorial cells the registry declares — and because step 2 keys the
+split on trial ids rather than positions, the reload costs nothing in
+disjointness.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from src.analysis.config.condition_registry import (
+    get_anova_factors,
+    get_conditions_obj,
+)
+from src.analysis.utils.general_utils import (
+    create_subjects_mne_objects_dict,
+    filter_electrode_lists_against_subjects_mne_objects,
+)
+
+from src.analysis.decoding.anova_electrode_selection import (
+    DEFAULT_STRATA_COLS,
+    DEFAULT_TRIAL_ID_COL,
+    apply_trial_partition,
+    assign_trial_partitions,
+    available_combo_names,
+    collect_subject_trial_strata,
+    combine_electrode_sets,
+    describe_electrode_set,
+    electrode_set_counts,
+    partition_trial_counts,
+    resolve_effect,
+    safe_effect_slug,
+    select_electrodes_by_windowed_anova,
+)
+
+
+def short_label(condition_label):
+    """``'stimulus_lwpc_conditions'`` → ``'lwpc'`` — a name fit for a filename."""
+    name = str(condition_label)
+    for prefix in ('stimulus_', 'response_'):
+        if name.startswith(prefix):
+            name = name[len(prefix):]
+            break
+    if name.endswith('_conditions'):
+        name = name[:-len('_conditions')]
+    return name or str(condition_label)
+
+
+def build_anova_selected_electrode_sets(
+    args,
+    rois,
+    electrodes,
+    decode_subjects_mne_objects,
+    save_dir,
+    LAB_root=None,
+):
+    """Split trials, select electrodes by ANOVA, and return the decode partition.
+
+    Parameters
+    ----------
+    args : namespace
+        Reads: ``subjects``, ``epochs_root_file``, ``task``, ``acc_trials_only``,
+        ``window_size``, ``step_size``, ``sampling_rate``, ``n_jobs``, and the
+        ``electrode_selection_*`` knobs (see ``run_decoding_dcc.py``).
+    electrodes : dict
+        ``{roi: {sub: [chan]}}`` — the candidate pool the ANOVA is run over
+        (whatever ``args.electrodes`` already narrowed it to).
+    decode_subjects_mne_objects : dict
+        The structure built from the *decode* conditions. Returned split down to
+        the decode partition.
+
+    Returns
+    -------
+    (decode_objects, electrode_sets, report)
+        ``electrode_sets`` maps set name → ``{roi: {sub: [chan]}}``.
+    """
+    labels = list(args.electrode_selection_condition_labels)
+    if not labels:
+        raise ValueError(
+            "anova_electrode_selection is on but "
+            "electrode_selection_condition_labels is empty — nothing to select on.")
+
+    frac_select = float(args.electrode_selection_frac)
+    seed = int(getattr(args, 'electrode_selection_seed', 0))
+    strata_cols = tuple(getattr(args, 'electrode_selection_strata', None)
+                        or DEFAULT_STRATA_COLS)
+    id_col = getattr(args, 'electrode_selection_trial_id_col', DEFAULT_TRIAL_ID_COL)
+
+    sel_dir = os.path.join(save_dir, 'electrode_selection')
+    os.makedirs(sel_dir, exist_ok=True)
+
+    print(f"\n{'='*20} ANOVA ELECTRODE SELECTION ON A HELD-OUT TRIAL SPLIT "
+          f"({frac_select:.0%} select / {1 - frac_select:.0%} decode) {'='*20}\n")
+    print(f"  selection condition sets: {labels}")
+    print(f"  stratified on: {list(strata_cols)}   trial id: {id_col}   seed: {seed}")
+
+    # --- 1. Load one epochs structure per selection condition set -------------
+    selection_structures = {}
+    for label in labels:
+        conditions_obj = get_conditions_obj(label)
+        print(f"\n[anova-select] loading epochs for selection set '{label}' "
+              f"({len(conditions_obj)} conditions)")
+        selection_structures[label] = create_subjects_mne_objects_dict(
+            subjects=args.subjects,
+            epochs_root_file=args.epochs_root_file,
+            conditions=conditions_obj,
+            task=args.task,
+            just_HG_ev1_rescaled=True,
+            acc_trials_only=args.acc_trials_only,
+            LAB_root=LAB_root,
+        )
+
+    # --- 2. One trial partition per subject, over every structure ------------
+    sub_trials = collect_subject_trial_strata(
+        [decode_subjects_mne_objects] + list(selection_structures.values()),
+        strata_cols=strata_cols, id_col=id_col,
+    )
+    partitions = assign_trial_partitions(sub_trials, frac_select=frac_select,
+                                         seed=seed)
+    n_sel_ids = sum(len(p['select']) for p in partitions.values())
+    n_dec_ids = sum(len(p['decode']) for p in partitions.values())
+    print(f"\n[anova-select] partitioned {n_sel_ids + n_dec_ids} trials across "
+          f"{len(partitions)} subjects: {n_sel_ids} selection / {n_dec_ids} decode")
+
+    # --- 3. Select electrodes on the selection partition, per condition set ---
+    named_sets = {}
+    per_label_report = {}
+    for label in labels:
+        name = short_label(label)
+        anova_factors = get_anova_factors(label)
+        if not anova_factors:
+            raise ValueError(
+                f"Selection condition set '{label}' has no 'anova_factors' in "
+                f"condition_registry.py — the ANOVA selector needs them.")
+
+        sel_structure = apply_trial_partition(
+            selection_structures[label], partitions, which='select', id_col=id_col)
+        # Candidate electrodes must exist in the *selection* epochs too.
+        candidates = filter_electrode_lists_against_subjects_mne_objects(
+            rois, electrodes, sel_structure)
+
+        print(f"\n[anova-select] --- '{name}' ({label}) --- factors={anova_factors}")
+        counts = partition_trial_counts(sel_structure)
+        if counts:
+            print(f"  selection trials per subject (min/median/max): "
+                  f"{min(counts.values())}/"
+                  f"{sorted(counts.values())[len(counts) // 2]}/"
+                  f"{max(counts.values())}")
+
+        effect_name = resolve_effect(args.electrode_selection_effect, anova_factors)
+        result = select_electrodes_by_windowed_anova(
+            sel_structure,
+            candidates,
+            rois,
+            args.subjects,
+            get_conditions_obj(label),
+            anova_factors,
+            effect=args.electrode_selection_effect,
+            window_size=args.window_size,
+            step_size=args.step_size,
+            sampling_rate=args.sampling_rate,
+            n_perm=int(args.electrode_selection_n_perm),
+            percentile=int(getattr(args, 'electrode_selection_percentile', 95)),
+            cluster_percentile=int(
+                getattr(args, 'electrode_selection_cluster_percentile', 95)),
+            min_trials_per_cell=int(
+                getattr(args, 'electrode_selection_min_trials_per_cell', 2)),
+            split_clusters_by_sign=bool(
+                getattr(args, 'electrode_selection_split_clusters_by_sign', True)),
+            use_fdr=bool(getattr(args, 'electrode_selection_use_fdr', True)),
+            alpha=float(getattr(args, 'electrode_selection_alpha', 0.05)),
+            seed=seed,
+            n_jobs=args.n_jobs,
+            verbose=True,
+            save_dir=sel_dir,
+            run_label=f"{name}_{safe_effect_slug(effect_name)}",
+        )
+        named_sets[name] = result['selected']
+        n_elec, n_subs = electrode_set_counts(result['selected'])
+        per_label_report[name] = {
+            'condition_label': label,
+            'anova_factors': list(anova_factors),
+            'effect': result['effect'],
+            'n_electrodes': n_elec,
+            'n_subjects': n_subs,
+            'n_skipped_electrodes': len(result['skipped']),
+            'subjects_used': result['subjects_used'],
+        }
+
+    # --- 4. Set algebra ------------------------------------------------------
+    requested = getattr(args, 'electrode_selection_sets', None)
+    if requested:
+        requested = list(requested)
+        allowed = available_combo_names(list(named_sets))
+        unknown = [r for r in requested if r not in allowed]
+        if unknown:
+            raise ValueError(
+                f"Unknown electrode_selection_sets {unknown}; available: {allowed}")
+    electrode_sets = combine_electrode_sets(named_sets, rois, combos=requested)
+
+    print(f"\n[anova-select] electrode sets built:")
+    for name, elecset in electrode_sets.items():
+        print(f"  - {describe_electrode_set(name, elecset)}")
+
+    # --- 5. Decode partition -------------------------------------------------
+    decode_objects = apply_trial_partition(
+        decode_subjects_mne_objects, partitions, which='decode', id_col=id_col)
+    dec_counts = partition_trial_counts(decode_objects)
+    print(f"\n[anova-select] decode partition: {len(decode_objects)} subjects, "
+          f"{sum(dec_counts.values())} trials in the decode conditions")
+
+    report = {
+        'frac_select': frac_select,
+        'seed': seed,
+        'strata_cols': list(strata_cols),
+        'trial_id_col': id_col,
+        'effect': args.electrode_selection_effect,
+        'use_fdr': bool(getattr(args, 'electrode_selection_use_fdr', True)),
+        'alpha': float(getattr(args, 'electrode_selection_alpha', 0.05)),
+        'n_perm': int(args.electrode_selection_n_perm),
+        'labels': per_label_report,
+        'sets': {name: {'n_electrodes': electrode_set_counts(es)[0],
+                        'n_subjects': electrode_set_counts(es)[1],
+                        'electrodes': {roi: {s: list(c) for s, c in by_sub.items() if c}
+                                       for roi, by_sub in es.items()}}
+                 for name, es in electrode_sets.items()},
+        'n_selection_trials': n_sel_ids,
+        'n_decode_trials': n_dec_ids,
+    }
+    report_path = os.path.join(sel_dir, 'electrode_selection_report.json')
+    with open(report_path, 'w') as f:
+        json.dump(report, f, indent=2, default=str)
+    print(f"[anova-select] wrote {report_path}")
+
+    return decode_objects, electrode_sets, report

--- a/src/analysis/decoding/run_context_comparisons.py
+++ b/src/analysis/decoding/run_context_comparisons.py
@@ -27,6 +27,7 @@ def run_all_context_comparisons(
     rois,
     save_dir,
     analysis_params_str,
+    electrode_set_desc_fn=None,
 ):
     kwargs = get_context_comparison_kwargs(args.condition_label)
     if kwargs is not None:
@@ -39,4 +40,5 @@ def run_all_context_comparisons(
             rois=rois,
             save_dir=save_dir,
             analysis_params_str=analysis_params_str,
+            electrode_set_desc_fn=electrode_set_desc_fn,
         )

--- a/src/analysis/decoding/run_debug_cm_traces.py
+++ b/src/analysis/decoding/run_debug_cm_traces.py
@@ -40,6 +40,7 @@ def run_debug_cm_traces(
     args,
     save_dir,
     analysis_params_str,
+    electrode_set_desc_fn=None,
 ):
     """
     Extract and plot pooled CM traces for debugging.
@@ -60,8 +61,13 @@ def run_debug_cm_traces(
         Base save directory.
     analysis_params_str : str
         String to append to filenames.
+    electrode_set_desc_fn : callable(roi) -> str, optional
+        One-line description of the electrode set decoded from; goes into the
+        figure title so a trace is attributable to its electrode set.
     """
     import os
+
+    from src.analysis.decoding.anova_electrode_selection import decoding_figure_title
 
     print("\n Extracting and plotting pooled CM traces for debugging...")
 
@@ -133,5 +139,8 @@ def run_debug_cm_traces(
                 single_column=args.single_column,
                 show_legend=True,
                 ylabel="Mean Trial Count",
+                title=decoding_figure_title(
+                    f"CM traces: {condition_comparison}", roi,
+                    electrode_set_desc_fn(roi) if electrode_set_desc_fn else None),
                 filename_suffix=analysis_params_str,
             )

--- a/tests/analysis/decoding/test_anova_electrode_selection.py
+++ b/tests/analysis/decoding/test_anova_electrode_selection.py
@@ -1,0 +1,296 @@
+"""Unit tests for the ANOVA electrode-selection path.
+
+Covers the pure pieces of ``src/analysis/decoding/anova_electrode_selection.py``:
+the trial-id-keyed partition (the property that makes selection and decoding
+disjoint *across different condition sets*), the summary-frame filter, the set
+algebra, and the naming. The ANOVA call itself needs real epochs and `ieeg`, so
+it is smoke-tested on the cluster, not here — same division as
+``test_trial_splitting.py``.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.analysis.decoding.anova_electrode_selection import (
+    apply_trial_partition,
+    assign_trial_partitions,
+    available_combo_names,
+    collect_subject_trial_strata,
+    combine_electrode_sets,
+    decoding_figure_title,
+    describe_electrode_set,
+    electrode_set_counts,
+    electrode_set_counts_for_roi,
+    electrode_set_slug,
+    interaction_effect_name,
+    pretty_electrode_set,
+    resolve_effect,
+    safe_effect_slug,
+    significant_electrodes_from_summary,
+)
+
+
+# --------------------------------------------------------------------------
+# A minimal Epochs stand-in: indexable, has .times / .metadata / len.
+# --------------------------------------------------------------------------
+class FakeEpochs:
+    def __init__(self, metadata, n_times=8):
+        self.metadata = metadata.reset_index(drop=True)
+        self.times = np.linspace(-1.0, 1.0, n_times)
+        self._data = np.zeros((len(self.metadata), 2, n_times))
+
+    def __len__(self):
+        return len(self.metadata)
+
+    def __getitem__(self, idx):
+        idx = np.asarray(idx)
+        return FakeEpochs(self.metadata.iloc[idx], n_times=len(self.times))
+
+    def get_data(self, *a, **k):
+        return self._data
+
+
+def _md(trial_ids, congruency=None, task_sequence=None):
+    n = len(trial_ids)
+    return pd.DataFrame({
+        'trial_count': np.asarray(trial_ids, dtype=float),
+        'congruency': congruency if congruency is not None else ['c', 'i'] * (n // 2) + ['c'] * (n % 2),
+        'task_sequence': task_sequence if task_sequence is not None else ['s', 'r'] * (n // 2) + ['s'] * (n % 2),
+    })
+
+
+def _structure(cond_to_ids, sub='D0001'):
+    return {sub: {cond: {'HG_ev1_power_rescaled': FakeEpochs(_md(ids))}
+                  for cond, ids in cond_to_ids.items()}}
+
+
+# ------------------------------ trial partition ----------------------------
+def test_partition_is_disjoint_and_covers_every_trial():
+    structure = _structure({'A': list(range(0, 20)), 'B': list(range(20, 40))})
+    sub_trials = collect_subject_trial_strata([structure])
+    parts = assign_trial_partitions(sub_trials, frac_select=0.3, seed=0)
+    sel, dec = parts['D0001']['select'], parts['D0001']['decode']
+    assert sel.isdisjoint(dec)
+    assert sel | dec == set(float(i) for i in range(40))
+
+
+def test_partition_respects_frac_select():
+    structure = _structure({'A': list(range(100))})
+    parts = assign_trial_partitions(
+        collect_subject_trial_strata([structure]), frac_select=0.3, seed=0)
+    n_sel = len(parts['D0001']['select'])
+    # 4 strata cells (c/i x s/r), rounding within each -> allow a few trials of slack
+    assert 26 <= n_sel <= 34
+
+
+def test_partition_is_shared_across_different_condition_sets():
+    """The property the whole design rests on.
+
+    The LWPC structure and the LWPS structure slice the SAME physical trials
+    into different conditions. A positional split would put trial 7 in the
+    selection half of one and the decode half of the other; keying on the trial
+    id cannot.
+    """
+    ids = list(range(40))
+    lwpc = _structure({'c25': ids[:20], 'i25': ids[20:]})
+    # Same trials, cut a different way.
+    lwps = _structure({'s25': ids[::2], 'r25': ids[1::2]})
+    decode = _structure({'all': ids})
+
+    parts = assign_trial_partitions(
+        collect_subject_trial_strata([decode, lwpc, lwps]),
+        frac_select=0.3, seed=0)
+
+    sel_lwpc = apply_trial_partition(lwpc, parts, which='select', verbose=False)
+    sel_lwps = apply_trial_partition(lwps, parts, which='select', verbose=False)
+    dec = apply_trial_partition(decode, parts, which='decode', verbose=False)
+
+    def ids_of(structure):
+        out = set()
+        for cond_dict in structure.values():
+            for obj in cond_dict.values():
+                out |= set(obj['HG_ev1_power_rescaled'].metadata['trial_count'])
+        return out
+
+    # Every selection trial, from EITHER selection condition set, is absent from
+    # the decode partition.
+    assert ids_of(sel_lwpc).isdisjoint(ids_of(dec))
+    assert ids_of(sel_lwps).isdisjoint(ids_of(dec))
+    # ...and the two selection sets see exactly the same physical trials.
+    assert ids_of(sel_lwpc) == ids_of(sel_lwps)
+
+
+def test_partition_is_deterministic():
+    structure = _structure({'A': list(range(30))})
+    a = assign_trial_partitions(collect_subject_trial_strata([structure]), seed=5)
+    b = assign_trial_partitions(collect_subject_trial_strata([structure]), seed=5)
+    assert a['D0001']['select'] == b['D0001']['select']
+
+
+def test_apply_partition_drops_empty_conditions():
+    # Condition B's trials all land on the selection side, so the decode side of
+    # B is empty and must be dropped rather than handed on as a 0-trial Epochs.
+    structure = _structure({'A': list(range(20)), 'B': [100]})
+    parts = {'D0001': {'select': {100.0} | set(float(i) for i in range(10)),
+                       'decode': set(float(i) for i in range(10, 20))}}
+    dec = apply_trial_partition(structure, parts, which='decode', verbose=False)
+    assert set(dec['D0001']) == {'A'}
+
+
+def test_apply_partition_drops_subject_with_nothing_left():
+    structure = _structure({'A': [1, 2, 3]})
+    parts = {'D0001': {'select': {1.0, 2.0, 3.0}, 'decode': set()}}
+    assert apply_trial_partition(structure, parts, which='decode',
+                                 verbose=False) == {}
+
+
+def test_missing_trial_id_column_raises():
+    md = pd.DataFrame({'congruency': ['c', 'i']})
+    structure = {'D0001': {'A': {'HG_ev1_power_rescaled': FakeEpochs(md)}}}
+    with pytest.raises(ValueError, match="trial_count"):
+        collect_subject_trial_strata([structure])
+
+
+# ------------------------------ effect naming ------------------------------
+def test_interaction_effect_name():
+    assert (interaction_effect_name(['congruency', 'incongruentProportion'])
+            == 'C(congruency):C(incongruentProportion)')
+
+
+def test_resolve_effect_variants():
+    factors = ['congruency', 'incongruentProportion']
+    assert resolve_effect('interaction', factors) == 'C(congruency):C(incongruentProportion)'
+    assert resolve_effect('any', factors) is None
+    assert resolve_effect('congruency', factors) == 'C(congruency)'
+    assert resolve_effect('C(weird)', factors) == 'C(weird)'
+    with pytest.raises(ValueError):
+        resolve_effect('interaction', ['congruency'])
+
+
+def test_safe_effect_slug():
+    assert safe_effect_slug('C(congruency):C(incongruentProportion)') == \
+        'congruency_x_incongruentProportion'
+    assert safe_effect_slug(None) == 'any_effect'
+
+
+# --------------------------- summary-frame filter --------------------------
+def _summary():
+    return pd.DataFrame([
+        # (sub, elec, roi, effect, sig_after_fdr, cluster_p)
+        ('D1', 'e1', 'lpfc', 'C(a):C(b)', True, 0.01),
+        ('D1', 'e2', 'lpfc', 'C(a):C(b)', False, 0.30),
+        ('D1', 'e2', 'lpfc', 'C(a)', True, 0.02),
+        ('D2', 'e9', 'lpfc', 'C(a):C(b)', True, 0.04),
+        ('D2', 'e8', 'lpfc', 'C(a):C(b)', False, 0.06),
+    ], columns=['subject', 'electrode', 'roi', 'effect', 'sig_after_fdr',
+                'cluster_p_value'])
+
+
+def test_summary_filter_by_effect_and_fdr():
+    candidates = {'lpfc': {'D1': ['e1', 'e2'], 'D2': ['e8', 'e9']}}
+    got = significant_electrodes_from_summary(
+        _summary(), ['lpfc'], candidates, effect_name='C(a):C(b)', use_fdr=True)
+    assert got['lpfc']['D1'] == ['e1']
+    assert got['lpfc']['D2'] == ['e9']
+
+
+def test_summary_filter_any_effect_picks_up_the_main_effect():
+    candidates = {'lpfc': {'D1': ['e1', 'e2']}}
+    got = significant_electrodes_from_summary(
+        _summary(), ['lpfc'], candidates, effect_name=None, use_fdr=True)
+    # e2 is not significant on the interaction but is on the main effect.
+    assert got['lpfc']['D1'] == ['e1', 'e2']
+
+
+def test_summary_filter_never_widens_the_candidate_pool():
+    candidates = {'lpfc': {'D1': ['e2']}}   # e1 is not a candidate here
+    got = significant_electrodes_from_summary(
+        _summary(), ['lpfc'], candidates, effect_name='C(a):C(b)', use_fdr=True)
+    assert got['lpfc']['D1'] == []
+
+
+def test_summary_filter_raw_p_route():
+    candidates = {'lpfc': {'D2': ['e8', 'e9']}}
+    got = significant_electrodes_from_summary(
+        _summary(), ['lpfc'], candidates, effect_name='C(a):C(b)',
+        use_fdr=False, alpha=0.05)
+    assert got['lpfc']['D2'] == ['e9']      # p=0.04 in, p=0.06 out
+
+
+def test_summary_filter_empty_frame():
+    got = significant_electrodes_from_summary(
+        pd.DataFrame(), ['lpfc'], {'lpfc': {'D1': ['e1']}})
+    assert got == {'lpfc': {}}
+
+
+# ------------------------------- set algebra -------------------------------
+@pytest.fixture
+def named_sets():
+    return {
+        'lwpc': {'lpfc': {'D1': ['a', 'b'], 'D2': ['x']}},
+        'lwps': {'lpfc': {'D1': ['b', 'c'], 'D2': []}},
+    }
+
+
+def test_combine_builds_unique_overlap_union(named_sets):
+    sets = combine_electrode_sets(named_sets, ['lpfc'])
+    assert sets['lwpc_only']['lpfc']['D1'] == ['a']
+    assert sets['lwps_only']['lpfc']['D1'] == ['c']
+    assert sets['overlap']['lpfc']['D1'] == ['b']
+    assert sorted(sets['union']['lpfc']['D1']) == ['a', 'b', 'c']
+    # An electrode only one subject has still lands in the right cells.
+    assert sets['lwpc_only']['lpfc']['D2'] == ['x']
+    assert sets['overlap']['lpfc']['D2'] == []
+
+
+def test_combine_labels_pass_through(named_sets):
+    sets = combine_electrode_sets(named_sets, ['lpfc'], combos=['lwpc', 'lwps'])
+    assert set(sets) == {'lwpc', 'lwps'}
+    assert sets['lwpc']['lpfc']['D1'] == ['a', 'b']
+
+
+def test_combine_rejects_unknown_combo(named_sets):
+    with pytest.raises(ValueError, match='Unknown electrode-set combination'):
+        combine_electrode_sets(named_sets, ['lpfc'], combos=['nonsense'])
+
+
+def test_available_combo_names():
+    assert available_combo_names(['lwpc', 'lwps']) == [
+        'lwpc', 'lwps', 'lwpc_only', 'lwps_only', 'overlap', 'union']
+    # A single label has no unique/overlap/union to speak of.
+    assert available_combo_names(['lwpc']) == ['lwpc']
+
+
+def test_same_channel_name_in_two_subjects_is_not_confused():
+    """Channel names are only unique within a subject."""
+    sets = combine_electrode_sets({
+        'lwpc': {'roi': {'D1': ['LFMM9'], 'D2': []}},
+        'lwps': {'roi': {'D1': [], 'D2': ['LFMM9']}},
+    }, ['roi'])
+    assert sets['overlap']['roi']['D1'] == []
+    assert sets['overlap']['roi']['D2'] == []
+    assert sets['lwpc_only']['roi']['D1'] == ['LFMM9']
+    assert sets['lwps_only']['roi']['D2'] == ['LFMM9']
+
+
+# --------------------------------- naming ----------------------------------
+def test_counts(named_sets):
+    assert electrode_set_counts(named_sets['lwpc']) == (3, 2)
+    assert electrode_set_counts_for_roi(named_sets['lwpc'], 'lpfc') == (3, 2)
+    assert electrode_set_counts_for_roi(named_sets['lwpc'], 'missing') == (0, 0)
+
+
+def test_slug_and_pretty():
+    assert electrode_set_slug('lwpc_only') == 'lwpc_only'
+    assert electrode_set_slug('C(a):C(b)') == 'C_a_C_b'
+    assert pretty_electrode_set('lwpc_only') == 'LWPC-only'
+    assert pretty_electrode_set('overlap') == 'overlap'
+
+
+def test_describe_and_title(named_sets):
+    desc = describe_electrode_set('lwpc_only', named_sets['lwpc'], roi='lpfc')
+    assert 'LWPC-only' in desc and 'n = 3' in desc
+    title = decoding_figure_title('c25_vs_i25', 'lpfc', desc)
+    assert title.splitlines()[0] == 'c25 vs i25 — lpfc'
+    assert 'LWPC-only' in title.splitlines()[1]

--- a/tests/analysis/decoding/test_anova_electrode_selection_integration.py
+++ b/tests/analysis/decoding/test_anova_electrode_selection_integration.py
@@ -1,0 +1,182 @@
+"""Integration test: does the ANOVA selector actually pick the right electrodes?
+
+The unit tests next door check the plumbing (partition, filter, set algebra).
+This one runs the **real** cluster-corrected windowed ANOVA
+(`run_within_electrode_windowed_anova_cluster_correction`) through
+`select_electrodes_by_windowed_anova` on synthetic data with a *planted*
+interaction, and asserts that:
+
+  * an electrode carrying a sustained congruency x incongruent-proportion
+    interaction is selected,
+  * a pure-noise electrode is not,
+  * an electrode with a strong *main effect* but no interaction is not selected
+    when the requested effect is the interaction — this is the specificity that
+    makes the LWPC/LWPS electrode sets mean what the guide (§3.1) says they mean.
+
+Only `process_windowed_data_for_anova` is stubbed, because it is the one step
+that needs real MNE Epochs (and `ieeg`); everything downstream of it is the
+production code path.
+
+A note on the planted effect size, learned the hard way. The permutation null
+here shuffles trial labels **within** an electrode and applies the *same* shuffle
+at every window, so any structure a shuffle accidentally retains shows up at
+*every* window at once. Plant a large enough effect (an offset of 3 σ in an
+earlier draft of this file) and the top few percent of permutations clear the
+pointwise threshold across the whole trace — the null's cluster-*extent*
+distribution piles up at full extent, `extent_threshold` reaches full extent
+too, and the strict `extent > threshold` test rejects the very effect that was
+planted. The offsets below are deliberately modest (≈0.8 σ) so the per-window
+noise, not the shuffle-alignment, sets the pointwise threshold. This is a
+property of an extent-based cluster test on a *temporally flat* effect, not a
+bug — but it is worth knowing before reading a null off a real run whose effect
+is sustained across the whole analysis window.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.slow
+
+import numpy as np
+import pandas as pd
+
+from src.analysis.decoding import anova_electrode_selection as aes
+
+DATA_SEED = 0          # a fresh RandomState per call -> order-independent tests
+EFFECT_SIZE = 0.8      # in SD units; see the module docstring on why not larger
+N_PERM = 40
+N_TRIALS = 24          # per condition, per subject
+N_WINDOWS = 8
+SUBJECTS = ['D0001', 'D0002']
+ROI = 'lpfc'
+CHANS = ['interaction', 'noise', 'main_effect_only']
+
+# The LWPC 2x2, exactly as the registry declares it.
+CONDITIONS_OBJ = {
+    'Stimulus_c25': {'congruency': 'c', 'incongruentProportion': '25%'},
+    'Stimulus_c75': {'congruency': 'c', 'incongruentProportion': '75%'},
+    'Stimulus_i25': {'congruency': 'i', 'incongruentProportion': '25%'},
+    'Stimulus_i75': {'congruency': 'i', 'incongruentProportion': '75%'},
+}
+ANOVA_FACTORS = ['congruency', 'incongruentProportion']
+
+
+def _cell_means(cond):
+    """Per-channel window-mean offsets for one condition cell.
+
+    'interaction'      : a difference-of-differences and nothing else
+                         (the congruency effect flips sign with proportion).
+    'noise'            : flat.
+    'main_effect_only' : a big congruency effect, identical in both blocks —
+                         so a main effect with a zero interaction.
+    """
+    cong = CONDITIONS_OBJ[cond]['congruency']
+    prop = CONDITIONS_OBJ[cond]['incongruentProportion']
+    c = +1.0 if cong == 'c' else -1.0
+    p = +1.0 if prop == '25%' else -1.0
+    return {'interaction': EFFECT_SIZE * c * p,
+            'noise': 0.0,
+            'main_effect_only': EFFECT_SIZE * c}
+
+
+def _fake_windowed_data(*args, **kwargs):
+    """Stand-in for process_windowed_data_for_anova.
+
+    Returns ``{condition: {roi: [per-subject (n_trials, n_windows, n_chans)]}}``
+    with the planted structure sustained across every window (so a cluster of
+    full extent forms) plus i.i.d. noise.
+    """
+    rng = np.random.RandomState(DATA_SEED)
+    out = {}
+    for cond in CONDITIONS_OBJ:
+        offsets = np.array([_cell_means(cond)[c] for c in CHANS])
+        per_sub = []
+        for _ in SUBJECTS:
+            noise = rng.randn(N_TRIALS, N_WINDOWS, len(CHANS))
+            per_sub.append(noise + offsets[None, None, :])
+        out[cond] = {ROI: per_sub}
+    return out
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    import src.analysis.power.windowed_anova as wa
+    monkeypatch.setattr(wa, 'process_windowed_data_for_anova', _fake_windowed_data)
+
+
+class _FakeEpochs:
+    """Only used for the `times` lookup and the usable-subject gate."""
+    def __init__(self, n=N_TRIALS):
+        self.times = np.linspace(-1.0, 1.5, 64)
+        self.metadata = pd.DataFrame({'trial_count': np.arange(n, dtype=float)})
+        self._n = n
+
+    def __len__(self):
+        return self._n
+
+    def __getitem__(self, idx):
+        return self
+
+    def get_data(self, *a, **k):
+        return np.zeros((self._n, len(CHANS), len(self.times)))
+
+
+def _selection_structure():
+    return {sub: {cond: {'HG_ev1_power_rescaled': _FakeEpochs()}
+                  for cond in CONDITIONS_OBJ}
+            for sub in SUBJECTS}
+
+
+def _run(effect, tmp_path, **kw):
+    return aes.select_electrodes_by_windowed_anova(
+        _selection_structure(),
+        {ROI: {sub: list(CHANS) for sub in SUBJECTS}},
+        [ROI],
+        SUBJECTS,
+        CONDITIONS_OBJ,
+        ANOVA_FACTORS,
+        effect=effect,
+        window_size=16, step_size=4, sampling_rate=256,
+        n_perm=N_PERM,
+        min_trials_per_cell=2,
+        seed=1, n_jobs=1, verbose=False,
+        save_dir=str(tmp_path), run_label='lwpc_test',
+        **kw,
+    )
+
+
+def test_selects_the_planted_interaction_electrode(patched, tmp_path):
+    result = _run('interaction', tmp_path)
+
+    assert result['effect'] == 'C(congruency):C(incongruentProportion)'
+    for sub in SUBJECTS:
+        picked = result['selected'][ROI][sub]
+        assert 'interaction' in picked, f"{sub}: planted interaction was missed"
+        assert 'noise' not in picked, f"{sub}: pure-noise electrode selected"
+        # Specificity: a main effect is not an interaction.
+        assert 'main_effect_only' not in picked, \
+            f"{sub}: main-effect-only electrode leaked into the interaction set"
+
+
+def test_main_effect_request_selects_the_main_effect_electrode(patched, tmp_path):
+    result = _run('congruency', tmp_path)
+    assert result['effect'] == 'C(congruency)'
+    for sub in SUBJECTS:
+        picked = result['selected'][ROI][sub]
+        assert 'main_effect_only' in picked
+        assert 'noise' not in picked
+
+
+def test_writes_an_inspectable_run_directory(patched, tmp_path):
+    _run('interaction', tmp_path)
+    run_dir = tmp_path / 'lwpc_test'
+    # The same artifacts a power_traces within-electrode ANOVA run writes, so a
+    # selection run can be inspected/re-loaded with the existing tooling.
+    assert (run_dir / 'summary.csv').exists()
+    assert (run_dir / 'run_config.json').exists()
+    assert (run_dir / ROI / SUBJECTS[0] / 'interaction.npz').exists()
+
+
+def test_every_candidate_subject_key_survives(patched, tmp_path):
+    """Downstream code indexes electrodes[roi][sub]; keys must not vanish."""
+    result = _run('interaction', tmp_path)
+    assert set(result['selected'][ROI]) == set(SUBJECTS)


### PR DESCRIPTION
…ials

Adds an option to spend a fraction of trials defining electrodes with the power-traces within-electrode windowed ANOVA (permutation cluster corrected) and decode on the disjoint remainder, once per electrode set.

The existing electrode_definition_split already did the trial split, but its selector is a task-responsiveness t-test and it yields a single electrode set, so it cannot ask whether different subpopulations carry stability vs. flexibility adaptation. What is new:

- src/analysis/decoding/anova_electrode_selection.py
  - a trial partition keyed on metadata['trial_count'] rather than each condition object's positional index. Selection runs over the LWPC 2x2 and the LWPS 2x2 while the decode runs over its own conditions; a positional split puts the same physical trial on both sides across condition sets.
  - select_electrodes_by_windowed_anova: the same call the power-traces job makes, on the selection partition, keeping electrodes with a surviving cluster on the requested effect (default the highest-order interaction). Writes a normal within-electrode-ANOVA run directory.
  - combine_electrode_sets: lwpc, lwps, lwpc_only, lwps_only, overlap, union.
  - naming helpers so every figure says what was decoded and from where.
- src/analysis/decoding/run_anova_electrode_selection.py: DCC orchestration.
- decoding_dcc.py: the battery is factored into run_decoding_for_one_electrode_set and looped over the requested sets, each into elecset_<name>/. Titles now carry the comparison, the ROI and the electrode set (with n); analysis_params_str carries the condition label and the set slug. With the option off, behaviour is unchanged apart from those names. Enabling both trial-split paths at once is now an error.
- submit_decoding_with_anova_electrode_selection_dcc.sh + env knobs in run_decoding_dcc.py.

Tests: 23 unit tests (split disjointness across condition sets, summary filter, set algebra, naming) plus an integration test that runs the real ANOVA on planted synthetic effects and checks a main-effect-only electrode does not leak into the interaction set.

Docs: guide §8.1/§8.2 (which selector when, how to read the per-set result and its three confounds), analysis_paths §13.1, and a note that the default STRATA for the older split names columns that do not exist in the metadata.


Claude-Session: https://claude.ai/code/session_01Eg5CsgnJNTwCJWMJYo7g9o