### PR TITLE
Fix cohens_d crash on time-course tables; add reference group + power…

### DIFF
--- a/dcc_scripts/decoding/README_stability_flexibility_cross_decoding.md
+++ b/dcc_scripts/decoding/README_stability_flexibility_cross_decoding.md
@@ -90,7 +90,8 @@ The A1 electrode definition still needs the long single-trial table
   electrode group (CPC/SPS/CPS/SPC), **skipping the diagonal** cell that would
   double-dip — see `cd.is_circular_decode`. Only the off-diagonal cells are kept.
 - **(a) label transfer:** train on stability, test on flexibility (and vice
-  versa), **separately** on the A1 `both`/`S_only`/`F_only` electrode groups.
+  versa), **separately** on the A1 `both`/`S_only`/`F_only` electrode groups,
+  plus the unselected reference group (`REFERENCE_GROUP`, default `all`).
   Prediction: only the `both` group cross-decodes.
 - **(c) temporal generalization (Fig 10):** train-window × test-window accuracy
   matrix, within a contrast and across contrasts. Off-diagonal generalization →
@@ -112,6 +113,54 @@ every trial. Two options for the diagonal (define == decode) cell:
 2. **Earn it** — define the electrodes on a disjoint set of trials
    (`trial_splitting.apply_electrode_definition_split`, `FRAC_DEF` env var).
 
+## Which electrodes are decoded
+
+Two independent choices, easy to conflate:
+
+1. **Which electrodes are loaded at all** — `ELECTRODES`. `sig` keeps the
+   baseline task-significant electrodes in the ROIs, `all` keeps every electrode
+   in them. (With `ROIS_DICT = None`, the current default, no ROI/significance
+   filter is applied and every channel is used.)
+2. **How those loaded electrodes are split for the decodes** — the groups.
+   `both`/`S_only`/`F_only` come from the interaction labels, and
+   `REFERENCE_GROUP` (default `all`) adds the **unselected** set: every channel
+   in the decoded ROI array.
+
+The reference group matters because `both`, `S_only` and `F_only` were each
+*chosen* for carrying an interaction, so none of them is a baseline for "does
+this ROI cross-decode at all" — the selection is exactly what inflates
+within-contrast decodability. The reference group is defined by nothing the
+decode is about. Set `REFERENCE_GROUP=''` to drop it.
+
+Temporal generalization costs `n_windows²` decodes per matrix, so it runs only on
+`TEMPGEN_GROUPS` (default `both`); use `TEMPGEN_GROUPS=both,all` to get the
+unselected comparison matrix too.
+
+## Electrode definition: `anova` vs `power_traces`
+
+`ELECTRODE_DEFINITION` picks how the S/F labels are derived. Both routes emit the
+same table (`CPC`/`SPS`/`CPS`/`SPC` + `S`/`F` aliases), so everything downstream
+is unchanged.
+
+| Route | What it fits | Trade-off |
+|---|---|---|
+| `anova` (default) | one two-way ANOVA per electrode on the **window-mean** HG over `[WINDOW_TMIN, WINDOW_TMAX]`, BH-FDR'd across electrodes | self-contained — it only needs the epochs this job already loads, which is why it is the default. A strong but **transient** interaction is diluted by the window mean. |
+| `power_traces` | reads the finished **within-electrode windowed ANOVA** runs and their permutation cluster correction (`power_traces_conjunction.electrode_labels`) | strictly more sensitive to transient interactions, and the decoded sets become literally the electrodes the power-trace figures call significant. Needs finished run directories. |
+
+For the `power_traces` route, point at either one run whose ANOVA carried all
+four interactions:
+
+```bash
+ELECTRODE_DEFINITION=power_traces POWER_TRACES_RUN_DIR=/path/to/run \
+  bash submit_stability_flexibility_cross_decoding_dcc.sh
+```
+
+or one directory per interaction (`POWER_TRACES_CPC`, `POWER_TRACES_SPS`,
+`POWER_TRACES_CPS`, `POWER_TRACES_SPC`). `POWER_TRACES_CORRECTION` chooses
+`fdr_bh` (BH across electrodes — the family a test that *counts* electrodes
+needs), `cluster` (raw cluster p, matching the existing lab convention), or
+`none`.
+
 ## Key knobs (env vars)
 
 | Variable | Default | Meaning |
@@ -119,9 +168,16 @@ every trial. Two options for the diagonal (define == decode) cell:
 | `DATA_SOURCE` | `real` | `real` = epoched data; `synthetic` = ground-truth dry run. |
 | `SYNTHETIC_CODE` | `shared` | synthetic only: `shared` (should cross-decode) or `orthogonal` (should not). |
 | `WINDOW_TMIN` / `WINDOW_TMAX` | `0.0` / `0.5` | analysis window (s from stimulus onset) for the A1 definition. |
-| `ELECTRODES` | `all` | `all` or `sig`. |
+| `ELECTRODES` | `all` | `all` or `sig` (baseline task-significant) — which electrodes are loaded. |
 | `ROI` | `all` | which ROI's LabeledArray to decode. |
 | `ALPHA` | `0.05` | A1 FDR threshold for the electrode groups. |
+| `ELECTRODE_DEFINITION` | `anova` | `anova` (in-job window-mean ANOVA) or `power_traces` (finished cluster-corrected runs). |
+| `POWER_TRACES_RUN_DIR` | unset | `power_traces` only: one run carrying all four interactions. |
+| `POWER_TRACES_CPC` / `_SPS` / `_CPS` / `_SPC` | unset | `power_traces` only: one run directory per interaction (overrides the single-run form). |
+| `POWER_TRACES_CORRECTION` | `fdr_bh` | `fdr_bh`, `cluster`, or `none`. |
+| `POWER_TRACES_ROI` | unset | `power_traces` only: restrict the labels to one ROI. |
+| `REFERENCE_GROUP` | `all` | name of the unselected all-electrode group; `''` drops it. |
+| `TEMPGEN_GROUPS` | `both` | comma-separated groups to run temporal generalization on; `''` skips it. |
 | `WINDOW_SIZE` | `20` | decoding window, in samples. |
 | `STEP_SIZE` | `10` | window stride, in samples. |
 | `N_SPLITS` | `5` | CV folds — or random resamples per repeat when `FRAC_TRAIN` is set. |
@@ -139,7 +195,8 @@ Written to `results/<epochs_or_synthetic_tag>/cross_decoding_window_<tmin>to<tma
   number of cluster-significant windows (bulky arrays stripped).
 - `accuracy_traces.npz` — the true and shuffle accuracy traces, for re-plotting.
 - `tempgen_*.npy` — the temporal-generalization matrices.
-- `anova_labels.csv` — the A1 electrode groups (real runs).
+- `anova_labels.csv` — the per-electrode definition table (real runs; written by
+  whichever `ELECTRODE_DEFINITION` route ran).
 - `cross_decoding_summary.png` — within-block bars, label-transfer traces by
   group, temporal-generalization matrices.
 - `summary.txt` — printed verdicts.

--- a/dcc_scripts/decoding/run_stability_flexibility_cross_decoding_dcc.py
+++ b/dcc_scripts/decoding/run_stability_flexibility_cross_decoding_dcc.py
@@ -68,9 +68,52 @@ WINDOW_TMIN = float(os.environ.get('WINDOW_TMIN', '0.0'))   # seconds post-stimu
 WINDOW_TMAX = float(os.environ.get('WINDOW_TMAX', '0.5'))
 
 # --- electrode selection + A1 electrode definition ---
+# Two independent choices, easy to conflate:
+#   ELECTRODES  = which electrodes are LOADED into the decoded ROI array at all.
+#                 'sig' keeps the baseline task-significant ones in the ROIs,
+#                 'all' keeps every electrode in the ROIs. (With ROIS_DICT=None
+#                 no ROI/significance filter is applied and every channel is used.)
+#   the GROUPS   = how those loaded electrodes are then split for the decodes:
+#                 both / S_only / F_only from the interaction labels, plus the
+#                 unselected REFERENCE_GROUP over all of them.
 ELECTRODES = os.environ.get('ELECTRODES', 'all')            # 'all' or 'sig'
 ROIS_DICT = None
 ALPHA = float(os.environ.get('ALPHA', '0.05'))
+
+# Which route defines the S/F electrode labels:
+#   'anova'        -- one ANOVA per electrode on window-mean HG over [WINDOW_TMIN,
+#                     WINDOW_TMAX], computed in this job (self-contained default).
+#   'power_traces' -- read the finished within-electrode WINDOWED ANOVA runs and
+#                     their permutation cluster correction, so the decoded sets
+#                     are exactly the electrodes the power-trace figures call
+#                     significant. More sensitive to transient interactions the
+#                     window mean dilutes; requires the run directories below.
+ELECTRODE_DEFINITION = os.environ.get('ELECTRODE_DEFINITION', 'anova')
+
+# power_traces route: either ONE run whose ANOVA carried all four interactions,
+#   POWER_TRACES_RUN_DIR=/path/to/run
+# or one directory per interaction,
+#   POWER_TRACES_CPC=... POWER_TRACES_SPS=... POWER_TRACES_CPS=... POWER_TRACES_SPC=...
+_pt_single = os.environ.get('POWER_TRACES_RUN_DIR')
+_pt_per_group = {g: os.environ.get(f'POWER_TRACES_{g}')
+                 for g in ('CPC', 'SPS', 'CPS', 'SPC')}
+_pt_per_group = {g: p for g, p in _pt_per_group.items() if p}
+POWER_TRACES_RUNS = _pt_per_group or _pt_single
+# 'fdr_bh' (BH across electrodes — the family a test that COUNTS electrodes
+# needs), 'cluster' (raw cluster p, matching the existing lab convention), or 'none'.
+POWER_TRACES_CORRECTION = os.environ.get('POWER_TRACES_CORRECTION', 'fdr_bh')
+POWER_TRACES_ROI = os.environ.get('POWER_TRACES_ROI')       # None = don't filter by ROI
+
+# The unselected reference set decoded alongside both/S_only/F_only: every
+# electrode in the decoded ROI array (so ELECTRODES above decides whether that
+# means "all" or "all baseline-significant"). Set REFERENCE_GROUP='' to drop it.
+REFERENCE_GROUP = os.environ.get('REFERENCE_GROUP', 'all')
+
+# Temporal generalization costs n_windows^2 decodes per matrix, so it runs on a
+# chosen subset of the groups. TEMPGEN_GROUPS='both,all' adds the unselected
+# reference matrix; TEMPGEN_GROUPS='' skips the design entirely.
+TEMPGEN_GROUPS = tuple(g.strip() for g in
+                       os.environ.get('TEMPGEN_GROUPS', 'both').split(',') if g.strip())
 
 # --- decoding hyperparameters (the ordinary pipeline's) ---
 WINDOW_SIZE = int(os.environ.get('WINDOW_SIZE', '20'))      # samples per decoding window
@@ -113,6 +156,12 @@ def run_analysis():
         electrodes=ELECTRODES,
         rois_dict=ROIS_DICT,
         alpha=ALPHA,
+        electrode_definition=ELECTRODE_DEFINITION,
+        power_traces_runs=POWER_TRACES_RUNS,
+        power_traces_correction=POWER_TRACES_CORRECTION,
+        power_traces_roi=POWER_TRACES_ROI,
+        reference_group=REFERENCE_GROUP,
+        tempgen_groups=TEMPGEN_GROUPS,
         roi=ROI,
         window_size=WINDOW_SIZE,
         step_size=STEP_SIZE,
@@ -137,6 +186,11 @@ def run_analysis():
     print(f"Analysis window:  [{WINDOW_TMIN}, {WINDOW_TMAX}] s")
     print(f"Electrodes:       {ELECTRODES}")
     print("-" * 72)
+    print(f"Elec definition:  {ELECTRODE_DEFINITION}"
+          + (f" (runs={POWER_TRACES_RUNS}, correction={POWER_TRACES_CORRECTION}, "
+             f"roi={POWER_TRACES_ROI})" if ELECTRODE_DEFINITION == 'power_traces' else ""))
+    print(f"Reference group:  {REFERENCE_GROUP or '(none)'} "
+          f"| temporal gen on: {list(TEMPGEN_GROUPS) or '(none)'}")
     print(f"alpha (A1):       {ALPHA} | ROI: {ROI}")
     print(f"window/step:      {WINDOW_SIZE}/{STEP_SIZE} samples "
           f"| n_splits: {N_SPLITS} | n_repeats: {N_REPEATS}")

--- a/dcc_scripts/decoding/stability_flexibility_cross_decoding_dcc.py
+++ b/dcc_scripts/decoding/stability_flexibility_cross_decoding_dcc.py
@@ -46,6 +46,7 @@ warnings.simplefilter(action='ignore', category=FutureWarning)
 
 import sys
 import os
+import re
 import json
 
 # ---------------------------------------------------------------------------
@@ -129,7 +130,9 @@ def save_results(results, save_dir):
                 arrays[f'labeltransfer_{group}_{direction}_true'] = r['acc_true']
                 arrays[f'labeltransfer_{group}_{direction}_shuffle'] = r['acc_shuffle']
     for name, res in results.get('temporal', {}).items():
-        np.save(os.path.join(save_dir, f'tempgen_{name}.npy'), res['matrix'])
+        # the keys carry '->', spaces and the '[group]' tag — keep them off disk
+        safe = re.sub(r'[^A-Za-z0-9]+', '_', name).strip('_')
+        np.save(os.path.join(save_dir, f'tempgen_{safe}.npy'), res['matrix'])
     if arrays:
         np.savez(os.path.join(save_dir, 'accuracy_traces.npz'), **arrays)
 
@@ -259,7 +262,13 @@ def write_summary(results, save_dir, meta):
 
     lines += ["-" * 72,
               "A4(a) label transfer (train stability, test flexibility) by group:",
-              "      prediction: only the 'both' group cross-decodes."]
+              "      prediction: only the 'both' group cross-decodes.",
+              f"      '{meta.get('reference_group') or 'all'}' is the UNSELECTED "
+              "reference set (every electrode in the",
+              "      decoded ROI array, i.e. what `electrodes` above already "
+              "restricted it to) —",
+              "      no interaction defined it, so it is the honest baseline for "
+              "the selected groups."]
     for g, res in results.get('label_transfer', {}).items():
         for direction, r in res.items():
             lines.append(
@@ -294,17 +303,84 @@ def write_summary(results, save_dir, meta):
 # ---------------------------------------------------------------------------
 # electrode-group derivation from the A1 labels
 # ---------------------------------------------------------------------------
-def _electrode_groups(df, alpha):
+# Two interchangeable routes to the same labels table (same columns, same
+# CPC/SPS/CPS/SPC + S/F contract), selected by `args.electrode_definition`:
+#
+#   'anova'        -- `sfs.per_electrode_anova_labels`: ONE two-way ANOVA per
+#                     electrode on the window-MEAN HG over [window_tmin,
+#                     window_tmax], BH-FDR'd across electrodes. Self-contained
+#                     (it only needs the epochs this job already loads), which
+#                     is why it was the original and only route here.
+#   'power_traces' -- `ptc.electrode_labels`: reads the already-computed
+#                     within-electrode WINDOWED ANOVA runs and their permutation
+#                     cluster correction, so an electrode counts as selective if
+#                     any cluster survives across time. Strictly more sensitive
+#                     to strong-but-transient interactions that the window mean
+#                     dilutes, and it makes the decoded electrode sets literally
+#                     the ones the power-trace figures call significant -- but it
+#                     needs finished run directories, which is the only reason it
+#                     is not the default.
+ELECTRODE_DEFINITIONS = ('anova', 'power_traces')
+
+
+def _channel_keys(labels):
+    """Labels rows -> the ROI LabeledArray's channel names (`f'{subject}-{elec}'`).
+
+    `put_data_in_labeled_array_per_roi_subject` labels channels `subject-electrode`
+    so they stay unique across the pseudopopulation. `per_electrode_anova_labels`
+    already emits that prefixed form in `electrode`; the power-traces route keeps
+    `subject` and a BARE `electrode` in separate columns. Normalising here is what
+    keeps `_restrict_to_electrodes` from silently matching nothing (which would
+    read as "this group has no electrode in the ROI" rather than as a key
+    mismatch).
+    """
+    subj = labels['subject'].astype(str)
+    elec = labels['electrode'].astype(str)
+    prefix = (subj + '-').to_numpy()
+    elec = elec.to_numpy()
+    # elementwise, since `Series.str.startswith` only takes a literal prefix
+    prefixed = np.fromiter((e.startswith(p) for e, p in zip(elec, prefix)),
+                           dtype=bool, count=len(elec))
+    return np.where(prefixed, elec, np.char.add(prefix.astype(str), elec.astype(str)))
+
+
+def _resolve_labels(args, df=None):
+    """The per-electrode S/F definition table, from whichever route is selected."""
+    definition = getattr(args, 'electrode_definition', 'anova')
+    if definition not in ELECTRODE_DEFINITIONS:
+        raise ValueError(f"electrode_definition must be one of {ELECTRODE_DEFINITIONS}; "
+                         f"got {definition!r}")
+
+    if definition == 'power_traces':
+        from src.analysis.stats import power_traces_conjunction as ptc
+        runs = getattr(args, 'power_traces_runs', None)
+        if not runs:
+            raise ValueError(
+                "electrode_definition='power_traces' needs `power_traces_runs`: "
+                "either one run directory whose ANOVA carried all four "
+                "interactions, or {'CPC': dir, 'SPS': dir, 'CPS': dir, 'SPC': dir}. "
+                "Set POWER_TRACES_RUN_DIR (or POWER_TRACES_CPC/SPS/CPS/SPC).")
+        return ptc.electrode_labels(
+            runs=runs,
+            roi=getattr(args, 'power_traces_roi', None),
+            alpha=args.alpha,
+            correction=getattr(args, 'power_traces_correction', 'fdr_bh'))
+
     from src.analysis.stats import stability_flexibility_segregation as sfs
-    labels = sfs.per_electrode_anova_labels(
-        df, alpha=alpha, contrast_mode=CONTRAST_MODE)
-    S = (labels.S == 1); F = (labels.F == 1)
-    groups = {
-        'both': labels.loc[S & F, 'electrode'].tolist(),
-        'S_only': labels.loc[S & ~F, 'electrode'].tolist(),
-        'F_only': labels.loc[~S & F, 'electrode'].tolist(),
+    return sfs.per_electrode_anova_labels(
+        df, alpha=args.alpha, contrast_mode=CONTRAST_MODE)
+
+
+def _electrode_groups(labels):
+    """The three DISJOINT label-transfer groups, as ROI-array channel names."""
+    chan = _channel_keys(labels)
+    S = (labels['S'] == 1).to_numpy()
+    F = (labels['F'] == 1).to_numpy()
+    return {
+        'both': chan[S & F].tolist(),
+        'S_only': chan[S & ~F].tolist(),
+        'F_only': chan[~S & F].tolist(),
     }
-    return labels, groups
 
 
 def _interaction_groups(labels):
@@ -312,8 +388,40 @@ def _interaction_groups(labels):
     the definition-group flag (CPC/SPS/CPS/SPC) so `cd.is_circular_decode` can name
     each set's double-dip cell. Used for the per-group within-block 2x2 that skips
     the diagonal (define==decode) cell."""
-    return {flag: labels.loc[labels[flag] == 1, 'electrode'].tolist()
+    chan = _channel_keys(labels)
+    return {flag: chan[(labels[flag] == 1).to_numpy()].tolist()
             for flag in ('CPC', 'SPS', 'CPS', 'SPC') if flag in labels.columns}
+
+
+def _add_reference_group(groups, channel_names, args):
+    """Add the UNSELECTED reference set: every channel in the decoded ROI array.
+
+    Without it, the label-transfer and temporal-generalization designs only ever
+    run on interaction-selected subsets (both / S_only / F_only), so there is no
+    baseline for "does this ROI cross-decode at all" -- and every one of those
+    subsets was chosen for carrying an interaction, which is exactly the
+    selection that inflates within-contrast decodability. The reference group is
+    defined by NOTHING the decode is about, so it is the honest comparison.
+
+    What "all" means is set upstream by `args.electrodes`: 'sig' restricts the
+    ROI array to the baseline task-significant electrodes, 'all' keeps every
+    electrode in the ROI. Either way this group is that array's full channel
+    list, so it is never a superset of what was actually loaded. Set
+    `args.reference_group` to None/'' to drop it.
+    """
+    name = getattr(args, 'reference_group', 'all')
+    if not name:
+        return groups
+    if name in groups:
+        raise ValueError(f"reference_group={name!r} collides with an existing "
+                         f"electrode group; pick another name")
+    channel_names = list(channel_names)
+    # On the synthetic path 'both' is already every channel by construction;
+    # adding a byte-identical group would just decode the same thing twice.
+    if any(set(v) == set(channel_names) for v in groups.values()):
+        return groups
+    groups[name] = channel_names
+    return groups
 
 
 def _restrict_to_electrodes(roi_labeled_arrays, roi, channel_names, keep):
@@ -367,20 +475,29 @@ def main(args):
             resolve_lab_root, resolve_electrodes_to_keep, load_HG_ev1_rescaled_per_subject)
         from src.analysis.utils.labeled_array_utils import (
             put_data_in_labeled_array_per_roi_subject)
-        from dcc_scripts.stats.stability_flexibility_segregation_dcc import assemble_long_df
 
+        definition = getattr(args, 'electrode_definition', 'anova')
+        print(f"ELECTRODE DEFINITION: {definition}")
         LAB_root = resolve_lab_root(args.LAB_root)
-        subjects_epochs = load_HG_ev1_rescaled_per_subject(
-            subjects=args.subjects, epochs_root_file=args.epochs_root_file,
-            task=args.task, LAB_root=LAB_root, acc_trials_only=args.acc_trials_only)
-        keep = resolve_electrodes_to_keep(args, LAB_root)
 
-        # (i) the A1 electrode definition needs the long single-trial table
-        df = assemble_long_df(subjects_epochs, args.window_tmin, args.window_tmax,
-                              electrodes_to_keep=keep, effect_measure=EFFECT_MEASURE)
-        print(f"assembled cluster df: {len(df)} rows | {df.subject.nunique()} subjects | "
-              f"{df.electrode.nunique()} electrodes")
-        labels, a1_groups = _electrode_groups(df, args.alpha)
+        # (i) the electrode definition. The power-traces route reads finished
+        #     windowed-ANOVA runs, so it needs neither the epochs nor the long
+        #     single-trial table; the in-job ANOVA route builds both.
+        if definition == 'power_traces':
+            labels = _resolve_labels(args)
+        else:
+            from dcc_scripts.stats.stability_flexibility_segregation_dcc import assemble_long_df
+            subjects_epochs = load_HG_ev1_rescaled_per_subject(
+                subjects=args.subjects, epochs_root_file=args.epochs_root_file,
+                task=args.task, LAB_root=LAB_root, acc_trials_only=args.acc_trials_only)
+            keep = resolve_electrodes_to_keep(args, LAB_root)
+            df = assemble_long_df(subjects_epochs, args.window_tmin, args.window_tmax,
+                                  electrodes_to_keep=keep, effect_measure=EFFECT_MEASURE)
+            print(f"assembled cluster df: {len(df)} rows | {df.subject.nunique()} subjects | "
+                  f"{df.electrode.nunique()} electrodes")
+            labels = _resolve_labels(args, df)
+
+        a1_groups = _electrode_groups(labels)
         labels.to_csv(os.path.join(args.save_dir, 'anova_labels.csv'), index=False)
         interaction_groups = _interaction_groups(labels)
         print("A1 electrode groups: "
@@ -393,6 +510,12 @@ def main(args):
             args.electrodes_per_subject_roi, obs_axs=0, chans_axs=1, time_axs=2,
             random_state=getattr(args, 'seed', 42))
         channel_names = list(args.roi_channel_names)
+
+    # The unselected reference set, so label transfer / temporal generalization
+    # are not only ever read off interaction-selected subsets.
+    a1_groups = _add_reference_group(a1_groups, channel_names, args)
+    print("decoded electrode groups: "
+          + "  ".join(f"{g}={len(v)}" for g, v in a1_groups.items()))
 
     results = {}
 
@@ -475,23 +598,33 @@ def main(args):
         lt[g] = entry
     results['label_transfer'] = lt
 
-    # 4. (c) temporal generalization (Fig 10) on the 'both' group ----------------
-    print("A4(c): temporal generalization (Fig 10)")
-    tg_set = a1_groups.get('both')
-    restricted, n_kept = (_restrict_to_electrodes(arrays, roi, channel_names, tg_set)
-                          if tg_set else (None, 0))
-    if n_kept >= args.min_group_size:
+    # 4. (c) temporal generalization (Fig 10) -----------------------------------
+    # Each matrix costs n_windows^2 decodes, so this runs on `args.tempgen_groups`
+    # (default: the 'both' group only) rather than on every group above. Add the
+    # reference group there to get the unselected comparison matrix too.
+    tempgen_groups = getattr(args, 'tempgen_groups', None) or ('both',)
+    print(f"A4(c): temporal generalization (Fig 10) on {list(tempgen_groups)}")
+    results['temporal'] = {}
+    for g in tempgen_groups:
+        tg_set = a1_groups.get(g)
+        restricted, n_kept = (_restrict_to_electrodes(arrays, roi, channel_names, tg_set)
+                              if tg_set else (None, 0))
+        if n_kept < args.min_group_size:
+            print(f"     group '{g}' has {n_kept} electrodes in ROI "
+                  f"(< {args.min_group_size}); skipping")
+            continue
         # n_windows^2 predictions — halve the repeats to keep the runtime sane
         tg_kw = dict(dec_kw, n_repeats=max(2, args.n_repeats // 2),
                      temporal_generalization=True)
-        results['temporal'] = {}
         for name, (tr, te) in (
                 ('stability (within)', (STAB_STRINGS, STAB_STRINGS)),
                 ('flexibility (within)', (FLEX_STRINGS, FLEX_STRINGS)),
                 ('stability->flexibility (cross)', (STAB_STRINGS, FLEX_STRINGS))):
             out = cd.run_cross_decoding(restricted, roi, tr, te, **tg_kw)
-            results['temporal'][name] = dict(matrix=_tempgen_matrix(out),
-                                             n_channels=n_kept)
+            results['temporal'][f'{name} [{g}]'] = dict(
+                matrix=_tempgen_matrix(out), n_channels=n_kept, group=g)
+    if not results['temporal']:
+        del results['temporal']
 
     # 5. persist + plot + summarize ----------------------------------------------
     save_results(results, args.save_dir)
@@ -501,6 +634,13 @@ def main(args):
         synthetic_code=getattr(args, 'synthetic_code', None),
         task=getattr(args, 'task', None),
         epochs_root_file=getattr(args, 'epochs_root_file', None),
+        electrodes=getattr(args, 'electrodes', None),
+        electrode_definition=getattr(args, 'electrode_definition', 'anova'),
+        power_traces_correction=(getattr(args, 'power_traces_correction', None)
+                                 if getattr(args, 'electrode_definition', 'anova')
+                                 == 'power_traces' else None),
+        reference_group=getattr(args, 'reference_group', 'all'),
+        electrode_group_sizes={g: len(v) for g, v in a1_groups.items()},
         window=f"[{getattr(args, 'window_tmin', None)}, {getattr(args, 'window_tmax', None)}]s",
         window_size=args.window_size, step_size=args.step_size,
         n_splits=args.n_splits, n_repeats=args.n_repeats,

--- a/src/analysis/stats/stability_flexibility_segregation.py
+++ b/src/analysis/stats/stability_flexibility_segregation.py
@@ -775,6 +775,24 @@ def per_electrode_labels(df, n_perm=2000, alpha=0.05, seed=2,
 # interaction but with a Type III ANOVA F rather than a within-electrode
 # permutation, so the two should agree closely and cross-check each other's
 # assumptions. Both feed `cmh_conjunction` unchanged (same output columns).
+def _scalar_hg(hg):
+    """Per-trial hg as plain scalars, reducing time-course cells to window means.
+
+    `assemble_long_df(..., effect_measure='cluster' | 'peak_t')` stores each
+    trial's windowed time COURSE in `hg` (one object cell per trial) so the
+    time-resolved measures can use it. The parametric ANOVA route in this
+    section is defined on the window MEAN, so every quantity it reports has to
+    be computed on that same reduction -- the fit in `_anova_interaction_stats`
+    and the `<g>_sign` direction that accompanies each F/p alike. Reducing in
+    only one of the two places is what made `per_electrode_anova_labels` raise
+    from `_require_scalar_hg` on a cluster-mode table.
+    """
+    hg = pd.Series(hg)
+    if hg.dtype == object:                   # cluster-mode time courses
+        return hg.apply(np.nanmean).to_numpy(dtype=float)
+    return hg.to_numpy(dtype=float)
+
+
 def _anova_interaction_stats(elec_df, cond_col, mod_col, hg_col='hg'):
     """One electrode's two-way Type III ANOVA; return {'F', 'p'} for the
     interaction term (NaN, NaN on a singular fit / missing cell).
@@ -786,7 +804,7 @@ def _anova_interaction_stats(elec_df, cond_col, mod_col, hg_col='hg'):
     is the window-mean scalar; a time-course cell is reduced to its mean."""
     d = elec_df
     if d[hg_col].dtype == object:            # cluster-mode time courses -> window mean
-        d = d.assign(**{hg_col: d[hg_col].apply(lambda a: np.nanmean(a))})
+        d = d.assign(**{hg_col: _scalar_hg(d[hg_col])})
     try:
         formula = f"{hg_col} ~ C({cond_col}, Sum) * C({mod_col}, Sum)"
         model = smf.ols(formula, data=d).fit()
@@ -844,6 +862,13 @@ def per_electrode_anova_labels(df, alpha=0.05, contrast_mode='proportion',
     module's own equal-cell-weight estimator `_interaction_effect(..., 'cohens_d')`
     -- the same quantity the continuous §2 correlation uses) so the direction can
     be REPORTED downstream, but it is not used to include or exclude electrodes.
+
+    This is the window-MEAN route throughout. A table built for a time-resolved
+    measure (`assemble_long_df(..., effect_measure='cluster' | 'peak_t')`) holds
+    per-trial time courses in `hg`; they are reduced to window means here, so
+    passing one is fine and the F/p and `<g>_sign` still describe the same
+    statistic. For a cluster-corrected, time-resolved definition use
+    `power_traces_conjunction` instead.
     FDR (Benjamini-Hochberg) is applied across electrodes per interaction; each
     flag is set at `alpha`."""
     contrasts = finalize_contrasts(df, resolve_contrasts(contrast_mode, contrasts))
@@ -859,7 +884,10 @@ def per_electrode_anova_labels(df, alpha=0.05, contrast_mode='proportion',
                   ('spc', 'switchType', 'incongruent_proportion', '_fcond', '_smod')]
     recs = []
     for (subj, elec), g in work.groupby(['subject', 'electrode']):
-        hg = g['hg'].to_numpy()
+        # Window means, matching the ANOVA fit below: a cluster-mode table holds
+        # per-trial time courses, and the signed direction has to describe the
+        # same statistic its F/p does (see `_scalar_hg`).
+        hg = _scalar_hg(g['hg'])
         rec = dict(subject=subj, electrode=elec)
         for name, cond_col, mod_col, cond_sub, mod_sub in specs:
             stats = _anova_interaction_stats(g, cond_col, mod_col)   # Type III, sum-coded

--- a/tests/analysis/decoding/test_cross_decoding_electrode_groups.py
+++ b/tests/analysis/decoding/test_cross_decoding_electrode_groups.py
@@ -1,0 +1,129 @@
+"""Electrode-group derivation for the A4 cross-decoding job.
+
+Covers the two things the job has to get right before any decoding happens:
+
+1. **Channel keys.** The decoded ROI LabeledArray labels channels
+   `f'{subject}-{electrode}'`. `per_electrode_anova_labels` already emits that
+   prefixed form, but the power-traces route
+   (`power_traces_conjunction.electrode_labels`) keeps `subject` and a BARE
+   `electrode` in separate columns. If the two are not normalised to one
+   convention, `_restrict_to_electrodes` matches nothing and the run silently
+   reports "group has 0 electrodes in ROI" instead of a key mismatch.
+
+2. **The unselected reference group.** both / S_only / F_only were all chosen
+   for carrying an interaction, so none of them is a baseline for "does this ROI
+   cross-decode at all". The reference group is every channel in the decoded
+   array, defined by nothing the decode is about.
+"""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from dcc_scripts.decoding import stability_flexibility_cross_decoding_dcc as xd
+
+
+def _anova_style_labels():
+    """`per_electrode_anova_labels` convention: `electrode` already prefixed."""
+    return pd.DataFrame(dict(
+        subject=['D1', 'D1', 'D2'],
+        electrode=['D1-A1', 'D1-A2', 'D2-B1'],
+        S=[1, 1, 0], F=[1, 0, 1],
+        CPC=[1, 1, 0], SPS=[1, 0, 1], CPS=[0, 0, 1], SPC=[0, 1, 0]))
+
+
+def _power_traces_style_labels():
+    """`ptc.electrode_labels` convention: bare `electrode`, same electrodes."""
+    return pd.DataFrame(dict(
+        subject=['D1', 'D1', 'D2'],
+        electrode=['A1', 'A2', 'B1'],
+        S=[1, 1, 0], F=[1, 0, 1],
+        CPC=[1, 1, 0], SPS=[1, 0, 1], CPS=[0, 0, 1], SPC=[0, 1, 0]))
+
+
+# ---------------------------------------------------------------------------
+# channel keys
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize('labels', [_anova_style_labels(), _power_traces_style_labels()])
+def test_channel_keys_match_the_roi_array_convention(labels):
+    assert list(xd._channel_keys(labels)) == ['D1-A1', 'D1-A2', 'D2-B1']
+
+
+def test_both_definition_routes_give_identical_groups():
+    """The route must not change WHICH channels a group names."""
+    assert (xd._electrode_groups(_anova_style_labels())
+            == xd._electrode_groups(_power_traces_style_labels()))
+    assert (xd._interaction_groups(_anova_style_labels())
+            == xd._interaction_groups(_power_traces_style_labels()))
+
+
+def test_groups_are_the_disjoint_s_f_partition():
+    groups = xd._electrode_groups(_anova_style_labels())
+    assert groups == {'both': ['D1-A1'], 'S_only': ['D1-A2'], 'F_only': ['D2-B1']}
+
+
+def test_interaction_groups_keyed_by_definition_flag():
+    inter = xd._interaction_groups(_anova_style_labels())
+    assert set(inter) == {'CPC', 'SPS', 'CPS', 'SPC'}
+    assert inter['CPC'] == ['D1-A1', 'D1-A2']
+
+
+def test_power_traces_keys_actually_slice_the_array():
+    """End-to-end on the restriction itself: bare-electrode labels must not
+    silently select zero channels."""
+    channel_names = ['D1-A1', 'D1-A2', 'D2-B1', 'D2-B2']
+    arrays = {'roi': {'cond': np.zeros((5, 4, 3))}}
+    groups = xd._electrode_groups(_power_traces_style_labels())
+    _, n_kept = xd._restrict_to_electrodes(arrays, 'roi', channel_names, groups['both'])
+    assert n_kept == 1
+
+
+# ---------------------------------------------------------------------------
+# the unselected reference group
+# ---------------------------------------------------------------------------
+def test_reference_group_is_every_channel_in_the_array():
+    channel_names = ['D1-A1', 'D1-A2', 'D2-B1', 'D2-B2']
+    groups = xd._add_reference_group(
+        xd._electrode_groups(_anova_style_labels()), channel_names,
+        SimpleNamespace(reference_group='all'))
+    assert groups['all'] == channel_names
+    # the selected groups are untouched
+    assert groups['both'] == ['D1-A1']
+
+
+def test_reference_group_can_be_opted_out():
+    groups = xd._add_reference_group(
+        {'both': ['D1-A1']}, ['D1-A1', 'D1-A2'],
+        SimpleNamespace(reference_group=''))
+    assert groups == {'both': ['D1-A1']}
+
+
+def test_reference_group_not_duplicated_when_a_group_already_covers_everything():
+    """The synthetic path's 'both' IS every channel — don't decode it twice."""
+    channel_names = ['ch0', 'ch1']
+    groups = xd._add_reference_group(
+        {'both': list(channel_names)}, channel_names,
+        SimpleNamespace(reference_group='all'))
+    assert 'all' not in groups
+
+
+def test_reference_group_name_collision_is_an_error():
+    with pytest.raises(ValueError, match='collides'):
+        xd._add_reference_group({'both': ['a']}, ['a', 'b'],
+                                SimpleNamespace(reference_group='both'))
+
+
+# ---------------------------------------------------------------------------
+# definition-route selection
+# ---------------------------------------------------------------------------
+def test_unknown_definition_route_is_rejected():
+    with pytest.raises(ValueError, match='electrode_definition must be'):
+        xd._resolve_labels(SimpleNamespace(electrode_definition='bogus', alpha=0.05))
+
+
+def test_power_traces_route_requires_run_directories():
+    with pytest.raises(ValueError, match='power_traces_runs'):
+        xd._resolve_labels(SimpleNamespace(electrode_definition='power_traces',
+                                           alpha=0.05, power_traces_runs=None))

--- a/tests/analysis/stats/test_stability_flexibility_anova_labels.py
+++ b/tests/analysis/stats/test_stability_flexibility_anova_labels.py
@@ -14,6 +14,7 @@ module's synthetic generator, whose ground truth has NO cross-effect, so CPS/SPC
 should stay ~null while CPC/SPS recover the planted interactions.
 """
 
+import numpy as np
 import pytest
 
 from src.analysis.stats import stability_flexibility_segregation as sfs
@@ -112,3 +113,53 @@ def test_no_sign_gating_option_is_exposed():
 
     params = inspect.signature(sfs.per_electrode_anova_labels).parameters
     assert "require_sign" not in params
+
+
+# ---------------------------------------------------------------------------
+# time-course (cluster-mode) input
+# ---------------------------------------------------------------------------
+# `assemble_long_df(..., effect_measure='cluster' | 'peak_t')` stores each trial's
+# windowed time COURSE in `hg`, and the cross-decoding battery builds its table
+# that way before calling this (window-mean) definition. The ANOVA fit already
+# reduced those cells to window means; the `<g>_sign` direction did not, so it
+# reached `_interaction_effect(..., 'cohens_d')` with a (n, T) array and raised
+# "effect_measure='cohens_d' requires scalar (window-mean) hg".
+@pytest.fixture(scope="module")
+def cluster_labels():
+    df = sfs._synthetic_df(effect_measure="cluster", n_time=12, seed=1)
+    assert df["hg"].dtype == object, "fixture is not a time-course table"
+    return sfs.per_electrode_anova_labels(df, alpha=0.05, contrast_mode="proportion")
+
+
+def test_accepts_time_course_table(cluster_labels):
+    """A cluster-mode table runs through instead of raising on the sign step."""
+    assert len(cluster_labels) > 0
+    for flag in ("CPC", "SPS", "CPS", "SPC"):
+        assert set(cluster_labels[flag].unique()) <= {0, 1}
+    assert cluster_labels["CPC"].sum() > 0 and cluster_labels["SPS"].sum() > 0
+
+
+def test_time_course_signs_are_scalar_and_signed(cluster_labels):
+    """Signs stay per-electrode scalars in {-1, +1} — not length-T vectors."""
+    for col in ("cpc_sign", "sps_sign", "cps_sign", "spc_sign"):
+        vals = cluster_labels[col].to_numpy()
+        assert vals.ndim == 1, f"{col} is not scalar per electrode"
+        assert set(np.unique(vals)) <= {-1.0, 0.0, 1.0}
+    # both modulation directions still represented (as in the scalar path)
+    assert (cluster_labels["cpc_sign"] > 0).any()
+    assert (cluster_labels["cpc_sign"] < 0).any()
+
+
+def test_time_course_matches_window_mean_table():
+    """Reduction is exactly the window mean: pre-averaging the cells gives the
+    same labels, so cluster-mode input is not a different analysis."""
+    df = sfs._synthetic_df(effect_measure="cluster", n_time=12, seed=3)
+    reduced = df.assign(hg=df["hg"].apply(np.nanmean))
+
+    from_courses = sfs.per_electrode_anova_labels(df, contrast_mode="proportion")
+    from_means = sfs.per_electrode_anova_labels(reduced, contrast_mode="proportion")
+
+    for col in ("q_cpc", "q_sps", "cpc_sign", "sps_sign"):
+        np.testing.assert_allclose(from_courses[col], from_means[col], rtol=1e-9)
+    for flag in ("CPC", "SPS", "CPS", "SPC"):
+        assert (from_courses[flag] == from_means[flag]).all()


### PR DESCRIPTION
…-traces definition

The A4 cross-decoding job assembles its long table with effect_measure='cluster' (per-trial time courses), then called per_electrode_anova_labels on it. That function fits its ANOVA on the window MEAN -- _anova_interaction_stats already reduced object cells -- but the accompanying <g>_sign went to _interaction_effect(..., 'cohens_d') with the raw (n, T) array, so _require_scalar_hg raised:

    ValueError: effect_measure='cohens_d' requires scalar (window-mean) hg,
    but the table holds time courses of length 385

Reduce in one shared place (_scalar_hg) so the F/p and the sign describe the same statistic. Verified the labels from a time-course table match those from a pre-averaged one exactly.

Also, on the cross-decoding job:

- Add the unselected reference group (REFERENCE_GROUP, default 'all') to the label-transfer and temporal-generalization designs. Previously those ran only on both/S_only/F_only, every one of which was chosen for carrying an interaction, so there was no baseline for whether the ROI cross-decodes at all. The group is every channel in the decoded ROI array, so ELECTRODES=sig|all still decides whether that means all electrodes or all baseline-significant ones.

- Add ELECTRODE_DEFINITION=anova|power_traces. The power_traces route reads finished within-electrode windowed-ANOVA runs and their cluster correction (power_traces_conjunction.electrode_labels, already a documented drop-in), which is more sensitive to transient interactions the window mean dilutes; it also skips the long-table assembly entirely. Normalise both routes' electrode keys to the ROI array's 'subject-electrode' convention, since power_traces keeps a bare electrode column and would otherwise match no channels silently.

- TEMPGEN_GROUPS makes temporal generalization's group list explicit (default 'both', unchanged runtime).


Claude-Session: https://claude.ai/code/session_01HtjJ177NA9SNYBbUx4yyjL