### PR TITLE
Make the cross-decoding real-data path actually run, and document how…

### DIFF
--- a/dcc_scripts/decoding/run_stability_flexibility_cross_decoding_dcc.py
+++ b/dcc_scripts/decoding/run_stability_flexibility_cross_decoding_dcc.py
@@ -39,6 +39,8 @@ if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
 from dcc_scripts.decoding.stability_flexibility_cross_decoding_dcc import main
+from src.analysis.config import experiment_conditions
+from src.analysis.config.rois import rois_dict as ALL_ROIS_DICT
 
 # ---------------------------------------------------------------------------
 # ANALYSIS PARAMETERS
@@ -67,17 +69,32 @@ if DATA_SOURCE == 'real' and EPOCHS_ROOT_FILE is None:
 WINDOW_TMIN = float(os.environ.get('WINDOW_TMIN', '0.0'))   # seconds post-stimulus
 WINDOW_TMAX = float(os.environ.get('WINDOW_TMAX', '0.5'))
 
-# --- electrode selection + A1 electrode definition ---
-# Two independent choices, easy to conflate:
-#   ELECTRODES  = which electrodes are LOADED into the decoded ROI array at all.
-#                 'sig' keeps the baseline task-significant ones in the ROIs,
-#                 'all' keeps every electrode in the ROIs. (With ROIS_DICT=None
-#                 no ROI/significance filter is applied and every channel is used.)
-#   the GROUPS   = how those loaded electrodes are then split for the decodes:
-#                 both / S_only / F_only from the interaction labels, plus the
-#                 unselected REFERENCE_GROUP over all of them.
-ELECTRODES = os.environ.get('ELECTRODES', 'all')            # 'all' or 'sig'
-ROIS_DICT = None
+# --- conditions ---
+# A4 transfers a classifier between congruency and switchType, and splits each by
+# a block proportion, so it needs the FULL 2x2x2x2 condition set — every
+# {congruency} x {incongruent proportion} x {switchType} x {switch proportion}
+# cell. `stimulus_experiment_conditions` is that set. The contrast and block
+# definitions are read off each condition's declared factor levels, so swapping
+# in another condition dict works as long as its entries carry `congruency`,
+# `switchType`, `incongruentProportion` and `switchProportion`.
+CONDITIONS = getattr(experiment_conditions,
+                     os.environ.get('CONDITIONS', 'stimulus_experiment_conditions'))
+
+# --- ROI + electrode selection ---
+# Three independent choices, easy to conflate:
+#   ROI + ROIS_DICT = which anatomical region's electrodes are decoded.
+#   ELECTRODES      = which of that region's electrodes are LOADED at all.
+#                     'sig' keeps the baseline task-significant ones, 'all' keeps
+#                     every electrode in the ROI.
+#   the GROUPS      = how those loaded electrodes are then split for the decodes:
+#                     both / S_only / F_only from the interaction labels, plus the
+#                     unselected REFERENCE_GROUP over all of them.
+ROI = os.environ.get('ROI', 'lpfc')                         # a key of ROIS_DICT
+ROIS_DICT = {ROI: ALL_ROIS_DICT[ROI]} if ROI in ALL_ROIS_DICT else None
+if DATA_SOURCE == 'real' and ROIS_DICT is None:
+    raise ValueError(f"ROI={ROI!r} is not in src/analysis/config/rois.py "
+                     f"(have {sorted(ALL_ROIS_DICT)}).")
+ELECTRODES = os.environ.get('ELECTRODES', 'sig')            # 'all' or 'sig'
 ALPHA = float(os.environ.get('ALPHA', '0.05'))
 
 # Which route defines the S/F electrode labels:
@@ -124,7 +141,6 @@ EXPLAINED_VARIANCE = float(os.environ.get('EXPLAINED_VARIANCE', '0.8'))
 N_PERM = int(os.environ.get('N_PERM', '500'))               # cluster-test permutations
 MIN_GROUP_SIZE = int(os.environ.get('MIN_GROUP_SIZE', '5'))  # min electrodes per group
 SEED = int(os.environ.get('SEED', '0'))
-ROI = os.environ.get('ROI', 'all')                          # which ROI's LabeledArray to decode
 
 # Proportion of trials used for TRAINING in each split. Unset (the default) keeps
 # StratifiedKFold, i.e. (N_SPLITS-1)/N_SPLITS. Set it to sweep the train/test
@@ -135,9 +151,13 @@ FRAC_TRAIN = os.environ.get('FRAC_TRAIN')
 FRAC_TRAIN = float(FRAC_TRAIN) if FRAC_TRAIN else None
 
 # --- output ---
+# The ROI, electrode set and definition route all change what was decoded, so
+# they go in the path — otherwise two runs overwrite each other's results.
 _tag = EPOCHS_ROOT_FILE if EPOCHS_ROOT_FILE else f'synthetic_{SYNTHETIC_CODE}'
-SAVE_DIR = os.path.join(current_script_dir, 'results', _tag,
-                        f'cross_decoding_window_{WINDOW_TMIN}to{WINDOW_TMAX}s_{ELECTRODES}')
+SAVE_DIR = os.environ.get('SAVE_DIR') or os.path.join(
+    current_script_dir, 'results', _tag,
+    f'cross_decoding_{ROI}_window_{WINDOW_TMIN}to{WINDOW_TMAX}s_'
+    f'{ELECTRODES}_{ELECTRODE_DEFINITION}')
 
 
 def run_analysis():
@@ -153,6 +173,7 @@ def run_analysis():
         epochs_root_file=EPOCHS_ROOT_FILE,
         window_tmin=WINDOW_TMIN,
         window_tmax=WINDOW_TMAX,
+        conditions=CONDITIONS,
         electrodes=ELECTRODES,
         rois_dict=ROIS_DICT,
         alpha=ALPHA,
@@ -184,14 +205,15 @@ def run_analysis():
     print(f"Task:             {TASK}")
     print(f"Epochs file:      {EPOCHS_ROOT_FILE}")
     print(f"Analysis window:  [{WINDOW_TMIN}, {WINDOW_TMAX}] s")
-    print(f"Electrodes:       {ELECTRODES}")
+    print(f"Conditions:       {len(CONDITIONS)} cells")
+    print(f"ROI:              {ROI} | electrodes: {ELECTRODES}")
     print("-" * 72)
     print(f"Elec definition:  {ELECTRODE_DEFINITION}"
           + (f" (runs={POWER_TRACES_RUNS}, correction={POWER_TRACES_CORRECTION}, "
              f"roi={POWER_TRACES_ROI})" if ELECTRODE_DEFINITION == 'power_traces' else ""))
     print(f"Reference group:  {REFERENCE_GROUP or '(none)'} "
           f"| temporal gen on: {list(TEMPGEN_GROUPS) or '(none)'}")
-    print(f"alpha (A1):       {ALPHA} | ROI: {ROI}")
+    print(f"alpha (A1):       {ALPHA}")
     print(f"window/step:      {WINDOW_SIZE}/{STEP_SIZE} samples "
           f"| n_splits: {N_SPLITS} | n_repeats: {N_REPEATS}")
     print("train fraction:   "

--- a/dcc_scripts/decoding/stability_flexibility_cross_decoding_dcc.py
+++ b/dcc_scripts/decoding/stability_flexibility_cross_decoding_dcc.py
@@ -23,10 +23,21 @@ Designs:
       Per interaction-defined electrode group, the diagonal (define == decode)
       cell is SKIPPED — see `cd.is_circular_decode`.
   (a) label transfer: train on stability, test on flexibility (and vice versa),
-      SEPARATELY on the A1 both / S_only / F_only groups. Prediction: only
-      'both' cross-decodes.
+      SEPARATELY on the both / S_only / F_only groups, plus the UNSELECTED
+      reference group (`args.reference_group`, default 'all' = every electrode in
+      the decoded ROI array). Prediction: only 'both' cross-decodes; the
+      reference group says what the region does before any selection.
   (c) temporal generalization (Fig 10): train-window × test-window accuracy
-      matrix, within a contrast and across contrasts (on the 'both' group).
+      matrix, within a contrast and across contrasts, on `args.tempgen_groups`
+      (default: the 'both' group).
+
+The S/F electrode groups come from either route — see `ELECTRODE_DEFINITIONS`:
+`args.electrode_definition='anova'` fits one window-mean ANOVA per electrode in
+this job, 'power_traces' reads the finished cluster-corrected windowed-ANOVA runs.
+
+Contrast and block definitions are read off each condition's declared factor
+levels (`cd.condition_cells`), not parsed out of condition names — the real and
+synthetic naming conventions collide on the obvious shorthand tokens.
 
 Design (b) "set comparison" is just the same contrast decoded within each
 electrode set — an ordinary decode with `electrodes` restricted — and is covered
@@ -83,11 +94,16 @@ STAB, FLEX, BOTH = "#2c7fb8", "#d95f0e", "#31a354"
 CONTRAST_MODE = 'proportion'
 EFFECT_MEASURE = 'cluster'
 
-# Class definitions in the project's substring convention. These must match how
-# the condition names are built (`config/experiment_conditions.py`); the synthetic
-# generator uses the same tokens so one set of strings drives both paths.
-STAB_STRINGS = [['_i_'], ['_c_']]        # congruency  : incongruent vs congruent
-FLEX_STRINGS = [['_s_'], ['_r_']]        # switch type : switch vs repeat
+# Class definitions are DERIVED from each condition's declared factor levels
+# (`cd.condition_cells`), not hand-written as substrings of the condition names.
+# The real and synthetic naming conventions collide on shorthand tokens — '75s'
+# is "switch trial in the 75%-incongruent block" under
+# `stimulus_experiment_conditions` and "75%-switch block" under the synthetic
+# generator — and picking the wrong one decodes the wrong contrast silently
+# rather than raising. See the note above `cd.condition_cells`.
+
+# how each block factor is spelled in result keys and figures
+_BLOCK_TAG = {'incongruent_proportion': 'incongruent', 'switch_proportion': 'switch'}
 
 
 # ---------------------------------------------------------------------------
@@ -441,6 +457,97 @@ def _restrict_to_electrodes(roi_labeled_arrays, roi, channel_names, keep):
 
 
 # ---------------------------------------------------------------------------
+# the decoded ROI pseudopopulation (real data)
+# ---------------------------------------------------------------------------
+def _build_roi_arrays(args, LAB_root):
+    """Load the epochs and build the ROI LabeledArray this job decodes.
+
+    Mirrors `decoding_dcc.main`'s setup so A4 decodes exactly what the ordinary
+    decoding job would: the same ROI/significance electrode resolution, the same
+    "filter against what actually survived epoching" step, and the same
+    pseudopopulation builder.
+
+    Returns `(roi, arrays, channel_names, cells)`, where `channel_names` is the
+    array's own channel labelling (`subject-electrode`, in order — the thing
+    `_restrict_to_electrodes` slices against) and `cells` is the condition->factor
+    table the contrasts are derived from.
+    """
+    from src.analysis.utils.general_utils import (
+        get_sig_chans_per_subject, make_sig_electrodes_per_subject_and_roi_dict,
+        load_subjects_electrodes_to_ROIs_dict, create_subjects_mne_objects_dict,
+        filter_electrode_lists_against_subjects_mne_objects,
+        print_summary_of_dropped_electrodes)
+    from src.analysis.utils.labeled_array_utils import (
+        put_data_in_labeled_array_per_roi_subject)
+
+    roi = args.roi
+    if args.rois_dict is None or roi not in args.rois_dict:
+        raise ValueError(
+            f"ROI {roi!r} is not in rois_dict (have "
+            f"{sorted(args.rois_dict or [])}); set ROI to one of them, or extend "
+            "ROIS_DICT in the runner.")
+
+    config_dir = os.path.join(project_root, 'src', 'analysis', 'config')
+    subjects_electrodestoROIs_dict = load_subjects_electrodes_to_ROIs_dict(
+        save_dir=config_dir, filename='subjects_electrodestoROIs_dict.json')
+    sig_chans_per_subject = get_sig_chans_per_subject(
+        args.subjects, args.epochs_root_file, task=args.task, LAB_root=LAB_root)
+    all_elecs, sig_elecs = make_sig_electrodes_per_subject_and_roi_dict(
+        args.rois_dict, subjects_electrodestoROIs_dict, sig_chans_per_subject)
+
+    if args.electrodes == 'all':
+        raw_electrodes = all_elecs
+    elif args.electrodes == 'sig':
+        raw_electrodes = sig_elecs
+    else:
+        raise ValueError(f"electrodes must be 'all' or 'sig'; got {args.electrodes!r}")
+
+    cells = cd.condition_cells(args.conditions)
+    condition_names = list(cells)
+    print(f"conditions: {len(condition_names)} full 2x2x2x2 cells "
+          f"(of {len(args.conditions)} in the condition set)")
+
+    subjects_mne_objects = create_subjects_mne_objects_dict(
+        subjects=args.subjects, epochs_root_file=args.epochs_root_file,
+        conditions={name: args.conditions[name] for name in condition_names},
+        task=args.task, just_HG_ev1_rescaled=True, LAB_root=LAB_root,
+        acc_trials_only=args.acc_trials_only)
+
+    # An electrode in the ROI dict may have been dropped during epoching; asking
+    # for it would index past the epochs object.
+    electrodes = filter_electrode_lists_against_subjects_mne_objects(
+        [roi], raw_electrodes, subjects_mne_objects)
+    print_summary_of_dropped_electrodes(raw_electrodes, electrodes)
+
+    arrays = put_data_in_labeled_array_per_roi_subject(
+        subjects_mne_objects, condition_names, [roi], args.subjects,
+        electrodes, obs_axs=0, chans_axs=1, time_axs=2,
+        random_state=getattr(args, 'seed', 42))
+    channel_names = _roi_channel_names(arrays, roi)
+    print(f"ROI {roi!r} pseudopopulation: {len(channel_names)} channels "
+          f"({args.electrodes} electrodes)")
+    return roi, arrays, channel_names, cells
+
+
+def _roi_channel_names(arrays, roi):
+    """The ROI LabeledArray's channel labels, in array order.
+
+    Layout is [Conditions, Trials, Channels, Timepoints], so channels are
+    `labels[2]`. Falls back to positional names only if the array carries no
+    labelling — in which case the electrode groups cannot match anything and the
+    caller is told rather than left with silently empty groups.
+    """
+    arr = arrays[roi]
+    labels = getattr(arr, 'labels', None)
+    if labels is not None and len(labels) > 2:
+        return [str(c) for c in labels[2]]
+    raise ValueError(
+        f"the ROI {roi!r} array carries no channel labelling, so the electrode "
+        "groups cannot be matched against it; expected a LabeledArray with "
+        "[Conditions, Trials, Channels, Timepoints] labels")
+
+
+# ---------------------------------------------------------------------------
 # orchestrator
 # ---------------------------------------------------------------------------
 def main(args):
@@ -462,6 +569,7 @@ def main(args):
         roi = 'synthetic'
         arrays = cd.synthetic_roi_labeled_arrays(
             code=args.synthetic_code, seed=getattr(args, 'seed', 0))
+        cells = cd.synthetic_condition_cells()
         n_ch = next(iter(arrays[roi].values())).shape[1]
         channel_names = [f'ch{i}' for i in range(n_ch)]
         half = n_ch // 2
@@ -473,8 +581,6 @@ def main(args):
         print("DATA SOURCE: real epoched data")
         from src.analysis.utils.general_utils import (
             resolve_lab_root, resolve_electrodes_to_keep, load_HG_ev1_rescaled_per_subject)
-        from src.analysis.utils.labeled_array_utils import (
-            put_data_in_labeled_array_per_roi_subject)
 
         definition = getattr(args, 'electrode_definition', 'anova')
         print(f"ELECTRODE DEFINITION: {definition}")
@@ -504,18 +610,21 @@ def main(args):
               + "  ".join(f"{g}={len(v)}" for g, v in a1_groups.items()))
 
         # (ii) the decode runs on the ordinary ROI LabeledArray pseudopopulation
-        roi = args.roi
-        arrays = put_data_in_labeled_array_per_roi_subject(
-            args.subjects_mne_objects, args.condition_names, [roi], args.subjects,
-            args.electrodes_per_subject_roi, obs_axs=0, chans_axs=1, time_axs=2,
-            random_state=getattr(args, 'seed', 42))
-        channel_names = list(args.roi_channel_names)
+        roi, arrays, channel_names, cells = _build_roi_arrays(args, LAB_root)
 
     # The unselected reference set, so label transfer / temporal generalization
     # are not only ever read off interaction-selected subsets.
     a1_groups = _add_reference_group(a1_groups, channel_names, args)
     print("decoded electrode groups: "
           + "  ".join(f"{g}={len(v)}" for g, v in a1_groups.items()))
+
+    # Contrasts and block sets, read off each condition's declared factor levels
+    # rather than parsed out of its name (see `cd.condition_cells`).
+    stab_strings, flex_strings = cd.stability_flexibility_strings(cells)
+    blocks = {'incongruent_proportion': cd.block_condition_sets(cells, 'incongruent_proportion'),
+              'switch_proportion': cd.block_condition_sets(cells, 'switch_proportion')}
+    print("block levels: "
+          + "  ".join(f"{f}={sorted(levels)}" for f, levels in blocks.items()))
 
     results = {}
 
@@ -524,21 +633,23 @@ def main(args):
     # block's conditions — restrict the conditions, then train == test contrast.
     print("A4(0): within-block decoding baseline (Fig 9)")
     within_block = {}
-    for cname, strings, block_tokens in (
-            ('congruency (LWPC)', STAB_STRINGS, ('25inc', '75inc')),
-            ('switchType (LWPS)', FLEX_STRINGS, ('25sw', '75sw'))):
+    for cname, strings, block_col in (
+            ('congruency (LWPC)', stab_strings, 'incongruent_proportion'),
+            ('switchType (LWPS)', flex_strings, 'switch_proportion')):
         per_block = {}
-        for token in block_tokens:
+        for level, conds in blocks[block_col].items():
+            tag = f'{level}% {_BLOCK_TAG[block_col]}'
             try:
-                sub_arrays = cd.filter_conditions(arrays, roi, token)
+                sub_arrays = cd.filter_conditions(arrays, roi, conds)
             except ValueError as e:
-                print(f"     skipping block {token}: {e}")
+                print(f"     skipping block {tag}: {e}")
                 continue
             out = cd.run_cross_decoding(sub_arrays, roi, strings, strings, **dec_kw)
-            per_block[token] = _summarise(out, **cluster_kw)
+            per_block[tag] = _summarise(out, **cluster_kw)
+        # low level first (block_condition_sets sorts), so this is high - low
         if len(per_block) == 2:
-            a, b = (per_block[t]['mean_accuracy'] for t in per_block)
-            diff = b - a
+            low, high = (per_block[t]['mean_accuracy'] for t in per_block)
+            diff = high - low
         else:
             diff = None
         within_block[cname] = dict(per_block=per_block, block_difference=diff)
@@ -553,10 +664,10 @@ def main(args):
     #     set of trials (`trial_splitting.apply_electrode_definition_split`).
     if interaction_groups:
         print("A4(0b): per-group within-block 2x2 (diagonal define==decode cells ignored)")
-        decode_cells = [('congruency', 'incongruent_proportion', STAB_STRINGS, ('25inc', '75inc')),
-                        ('congruency', 'switch_proportion', STAB_STRINGS, ('25sw', '75sw')),
-                        ('switchType', 'switch_proportion', FLEX_STRINGS, ('25sw', '75sw')),
-                        ('switchType', 'incongruent_proportion', FLEX_STRINGS, ('25inc', '75inc'))]
+        decode_cells = [('congruency', 'incongruent_proportion', stab_strings),
+                        ('congruency', 'switch_proportion', stab_strings),
+                        ('switchType', 'switch_proportion', flex_strings),
+                        ('switchType', 'incongruent_proportion', flex_strings)]
         per_group = {}
         for gflag, elset in interaction_groups.items():
             restricted, n_kept = _restrict_to_electrodes(arrays, roi, channel_names, elset)
@@ -564,20 +675,21 @@ def main(args):
                 print(f"     group '{gflag}' has {n_kept} electrodes in ROI "
                       f"(< {args.min_group_size}); skipping")
                 continue
-            cells = {}
-            for contrast, block_col, strings, tokens in decode_cells:
+            decoded = {}
+            for contrast, block_col, strings in decode_cells:
                 if cd.is_circular_decode(gflag, contrast, block_col):
                     continue                     # double-dipping: ignore this result
-                for token in tokens:
+                for level, conds in blocks[block_col].items():
                     try:
-                        sub_arrays = cd.filter_conditions(restricted, roi, token)
+                        sub_arrays = cd.filter_conditions(restricted, roi, conds)
                     except ValueError:
                         continue
                     out = cd.run_cross_decoding(sub_arrays, roi, strings, strings, **dec_kw)
-                    cells[f'{contrast} by {block_col} [{token}]'] = _summarise(out, **cluster_kw)
+                    tag = f'{contrast} by {block_col} [{level}%]'
+                    decoded[tag] = _summarise(out, **cluster_kw)
             per_group[gflag] = dict(n_electrodes=n_kept,
                                     ignored_cell=cd.circular_decode_for_group(gflag),
-                                    cells=cells)
+                                    cells=decoded)
         results['within_block_by_group'] = per_group
 
     # 3. (a) label transfer per electrode group ----------------------------------
@@ -590,8 +702,8 @@ def main(args):
                   f"(< {args.min_group_size}); skipping")
             continue
         entry = {}
-        for direction, (tr, te) in (('stab_to_flex', (STAB_STRINGS, FLEX_STRINGS)),
-                                    ('flex_to_stab', (FLEX_STRINGS, STAB_STRINGS))):
+        for direction, (tr, te) in (('stab_to_flex', (stab_strings, flex_strings)),
+                                    ('flex_to_stab', (flex_strings, stab_strings))):
             out = cd.run_cross_decoding(restricted, roi, tr, te, **dec_kw)
             entry[direction] = _summarise(out, **cluster_kw)
             entry[direction]['n_channels'] = n_kept
@@ -606,9 +718,13 @@ def main(args):
     print(f"A4(c): temporal generalization (Fig 10) on {list(tempgen_groups)}")
     results['temporal'] = {}
     for g in tempgen_groups:
-        tg_set = a1_groups.get(g)
-        restricted, n_kept = (_restrict_to_electrodes(arrays, roi, channel_names, tg_set)
-                              if tg_set else (None, 0))
+        if g not in a1_groups:
+            # e.g. the reference group was folded into an identical existing one
+            print(f"     no electrode group named '{g}' "
+                  f"(have {sorted(a1_groups)}); skipping")
+            continue
+        restricted, n_kept = _restrict_to_electrodes(
+            arrays, roi, channel_names, a1_groups[g])
         if n_kept < args.min_group_size:
             print(f"     group '{g}' has {n_kept} electrodes in ROI "
                   f"(< {args.min_group_size}); skipping")
@@ -617,9 +733,9 @@ def main(args):
         tg_kw = dict(dec_kw, n_repeats=max(2, args.n_repeats // 2),
                      temporal_generalization=True)
         for name, (tr, te) in (
-                ('stability (within)', (STAB_STRINGS, STAB_STRINGS)),
-                ('flexibility (within)', (FLEX_STRINGS, FLEX_STRINGS)),
-                ('stability->flexibility (cross)', (STAB_STRINGS, FLEX_STRINGS))):
+                ('stability (within)', (stab_strings, stab_strings)),
+                ('flexibility (within)', (flex_strings, flex_strings)),
+                ('stability->flexibility (cross)', (stab_strings, flex_strings))):
             out = cd.run_cross_decoding(restricted, roi, tr, te, **tg_kw)
             results['temporal'][f'{name} [{g}]'] = dict(
                 matrix=_tempgen_matrix(out), n_channels=n_kept, group=g)

--- a/dcc_scripts/decoding/submit_stability_flexibility_cross_decoding_dcc.sh
+++ b/dcc_scripts/decoding/submit_stability_flexibility_cross_decoding_dcc.sh
@@ -7,24 +7,31 @@
 # the only addition is a second label vector, so the hyperparameters below are
 # the same ones the main decoding job uses.
 #
-# Usage:
-#   bash submit_stability_flexibility_cross_decoding_dcc.sh                        # real data
-#   DATA_SOURCE=synthetic bash submit_stability_flexibility_cross_decoding_dcc.sh  # dry-run
-#   DATA_SOURCE=synthetic SYNTHETIC_CODE=orthogonal bash submit_..._dcc.sh         # null code
-#   FRAC_TRAIN=0.5 bash submit_stability_flexibility_cross_decoding_dcc.sh         # set the
-#                                                                                 # train/test split
+# Every variable below can be overridden from the environment, so you never have
+# to edit this file to change a run:
+#
+#   bash submit_stability_flexibility_cross_decoding_dcc.sh                    # real data, defaults
+#   ROI=acc bash submit_stability_flexibility_cross_decoding_dcc.sh            # a different region
+#   ELECTRODES=all bash submit_..._dcc.sh                                      # every ROI electrode
+#   DATA_SOURCE=synthetic bash submit_..._dcc.sh                               # ground-truth dry run
+#   DATA_SOURCE=synthetic SYNTHETIC_CODE=orthogonal bash submit_..._dcc.sh     # the null code
+#   TEMPGEN_GROUPS=both,all bash submit_..._dcc.sh                             # + unselected tempgen
+#   FRAC_TRAIN=0.5 bash submit_..._dcc.sh                                      # set the train/test split
+#   ELECTRODE_DEFINITION=power_traces POWER_TRACES_RUN_DIR=/path/to/run \
+#       bash submit_..._dcc.sh                                                 # define electrodes from
+#                                                                              # the power-trace runs
+#
+# See README_stability_flexibility_cross_decoding.md for what each knob does.
 
 # ---------------------------------------------------------------------------
-# Epochs file (high-gamma, rescaled). Match one you actually have on disk.
+# Data in: epochs file (high-gamma, rescaled) and the condition set.
 # ---------------------------------------------------------------------------
-EPOCHS_ROOT_FILE="Stimulus_-1.0to1.5sec_0.5sec_within-1.0-0.0sec_base_decFactor_8_outliers_10_drop_thresh_perc_5.0_70.0-150.0_Hz_padLength_1.5s_filterbank_hilbert_stat_func_ttest_ind_equal_var_False_nan_policy_omit"
+EPOCHS_ROOT_FILE=${EPOCHS_ROOT_FILE:-"Stimulus_-1.0to1.5sec_0.5sec_within-1.0-0.0sec_base_decFactor_8_outliers_10_drop_thresh_perc_5.0_70.0-150.0_Hz_padLength_1.5s_filterbank_hilbert_stat_func_ttest_ind_equal_var_False_nan_policy_omit"}
 
-# ---------------------------------------------------------------------------
-# Analysis window (seconds relative to stimulus onset) and electrode set.
-# ---------------------------------------------------------------------------
-WINDOW_TMIN=0.0
-WINDOW_TMAX=0.5
-ELECTRODES=all            # 'all' or 'sig'
+# A4 needs the FULL 2x2x2x2 (congruency x inc-proportion x switchType x
+# switch-proportion) — it decodes one contrast, scores the other, and splits
+# each by a block factor.
+CONDITIONS=${CONDITIONS:-stimulus_experiment_conditions}
 
 # Data source: 'real' loads epoched data; 'synthetic' validates the whole path
 # with a ground-truth pseudopopulation. SYNTHETIC_CODE picks the planted truth:
@@ -33,18 +40,51 @@ ELECTRODES=all            # 'all' or 'sig'
 DATA_SOURCE=${DATA_SOURCE:-real}
 SYNTHETIC_CODE=${SYNTHETIC_CODE:-shared}
 
-# A1 electrode definition.
-ALPHA=${ALPHA:-0.05}
-ROI=${ROI:-all}                      # which ROI's LabeledArray to decode
+# ---------------------------------------------------------------------------
+# Which electrodes. Three separate choices:
+#   ROI              which region (a key of src/analysis/config/rois.py)
+#   ELECTRODES       which of that region's electrodes get loaded at all
+#   REFERENCE_GROUP  the unselected group decoded alongside both/S_only/F_only
+# ---------------------------------------------------------------------------
+ROI=${ROI:-lpfc}
+ELECTRODES=${ELECTRODES:-sig}            # 'sig' (baseline task-significant) or 'all'
+REFERENCE_GROUP=${REFERENCE_GROUP:-all}  # '' to drop it
+MIN_GROUP_SIZE=${MIN_GROUP_SIZE:-5}      # skip electrode groups smaller than this
 
+# ---------------------------------------------------------------------------
+# How the S/F electrode groups are defined.
+#   anova         one ANOVA per electrode on the window-mean HG over
+#                 [WINDOW_TMIN, WINDOW_TMAX], computed in this job
+#   power_traces  read the finished within-electrode windowed-ANOVA runs and
+#                 their cluster correction (needs the run directories)
+# ---------------------------------------------------------------------------
+ELECTRODE_DEFINITION=${ELECTRODE_DEFINITION:-anova}
+WINDOW_TMIN=${WINDOW_TMIN:-0.0}          # seconds relative to stimulus onset
+WINDOW_TMAX=${WINDOW_TMAX:-0.5}
+ALPHA=${ALPHA:-0.05}
+
+POWER_TRACES_RUN_DIR=${POWER_TRACES_RUN_DIR:-}   # one run with all four interactions
+POWER_TRACES_CPC=${POWER_TRACES_CPC:-}           # ...or one directory per interaction
+POWER_TRACES_SPS=${POWER_TRACES_SPS:-}
+POWER_TRACES_CPS=${POWER_TRACES_CPS:-}
+POWER_TRACES_SPC=${POWER_TRACES_SPC:-}
+POWER_TRACES_CORRECTION=${POWER_TRACES_CORRECTION:-fdr_bh}  # fdr_bh | cluster | none
+POWER_TRACES_ROI=${POWER_TRACES_ROI:-}
+
+# ---------------------------------------------------------------------------
 # Decoding hyperparameters (the ordinary pipeline's).
+# ---------------------------------------------------------------------------
 WINDOW_SIZE=${WINDOW_SIZE:-20}       # decoding window, in samples
 STEP_SIZE=${STEP_SIZE:-10}           # window stride, in samples
 N_SPLITS=${N_SPLITS:-5}              # CV folds (or resamples per repeat, see FRAC_TRAIN)
-N_REPEATS=${N_REPEATS:-10}           # CV repeats
+N_REPEATS=${N_REPEATS:-10}           # CV repeats — the main runtime lever
 EXPLAINED_VARIANCE=${EXPLAINED_VARIANCE:-0.8}
 N_PERM=${N_PERM:-500}                # permutations for the cluster test over windows
-MIN_GROUP_SIZE=${MIN_GROUP_SIZE:-5}  # skip electrode groups smaller than this
+SEED=${SEED:-0}
+
+# Temporal generalization costs n_windows^2 decodes per matrix, so it runs only
+# on these groups. 'both,all' adds the unselected reference matrix; '' skips it.
+TEMPGEN_GROUPS=${TEMPGEN_GROUPS:-both}
 
 # Proportion of trials used for TRAINING in each split. Leave empty to keep
 # StratifiedKFold at (N_SPLITS-1)/N_SPLITS; set it to sweep the proportion
@@ -53,7 +93,8 @@ FRAC_TRAIN=${FRAC_TRAIN:-}
 
 mkdir -p out
 
-echo "Submitting stability/flexibility A4 cross-decoding (source=$DATA_SOURCE)"
-sbatch --job-name="sf_xdecode_${DATA_SOURCE}" \
-    --export=ALL,EPOCHS_ROOT_FILE="$EPOCHS_ROOT_FILE",WINDOW_TMIN="$WINDOW_TMIN",WINDOW_TMAX="$WINDOW_TMAX",ELECTRODES="$ELECTRODES",DATA_SOURCE="$DATA_SOURCE",SYNTHETIC_CODE="$SYNTHETIC_CODE",ALPHA="$ALPHA",ROI="$ROI",WINDOW_SIZE="$WINDOW_SIZE",STEP_SIZE="$STEP_SIZE",N_SPLITS="$N_SPLITS",N_REPEATS="$N_REPEATS",EXPLAINED_VARIANCE="$EXPLAINED_VARIANCE",FRAC_TRAIN="$FRAC_TRAIN",N_PERM="$N_PERM",MIN_GROUP_SIZE="$MIN_GROUP_SIZE" \
+echo "Submitting stability/flexibility A4 cross-decoding"
+echo "  source=$DATA_SOURCE  roi=$ROI  electrodes=$ELECTRODES  definition=$ELECTRODE_DEFINITION"
+sbatch --job-name="sf_xdecode_${DATA_SOURCE}_${ROI}" \
+    --export=ALL,EPOCHS_ROOT_FILE="$EPOCHS_ROOT_FILE",CONDITIONS="$CONDITIONS",WINDOW_TMIN="$WINDOW_TMIN",WINDOW_TMAX="$WINDOW_TMAX",ELECTRODES="$ELECTRODES",DATA_SOURCE="$DATA_SOURCE",SYNTHETIC_CODE="$SYNTHETIC_CODE",ALPHA="$ALPHA",ROI="$ROI",ELECTRODE_DEFINITION="$ELECTRODE_DEFINITION",POWER_TRACES_RUN_DIR="$POWER_TRACES_RUN_DIR",POWER_TRACES_CPC="$POWER_TRACES_CPC",POWER_TRACES_SPS="$POWER_TRACES_SPS",POWER_TRACES_CPS="$POWER_TRACES_CPS",POWER_TRACES_SPC="$POWER_TRACES_SPC",POWER_TRACES_CORRECTION="$POWER_TRACES_CORRECTION",POWER_TRACES_ROI="$POWER_TRACES_ROI",REFERENCE_GROUP="$REFERENCE_GROUP",TEMPGEN_GROUPS="$TEMPGEN_GROUPS",WINDOW_SIZE="$WINDOW_SIZE",STEP_SIZE="$STEP_SIZE",N_SPLITS="$N_SPLITS",N_REPEATS="$N_REPEATS",EXPLAINED_VARIANCE="$EXPLAINED_VARIANCE",FRAC_TRAIN="$FRAC_TRAIN",N_PERM="$N_PERM",MIN_GROUP_SIZE="$MIN_GROUP_SIZE",SEED="$SEED" \
     sbatch_stability_flexibility_cross_decoding_dcc.sh

--- a/dcc_scripts/decoding/submit_stability_flexibility_cross_decoding_dcc.sh
+++ b/dcc_scripts/decoding/submit_stability_flexibility_cross_decoding_dcc.sh
@@ -21,7 +21,7 @@
 #       bash submit_..._dcc.sh                                                 # define electrodes from
 #                                                                              # the power-trace runs
 #
-# See README_stability_flexibility_cross_decoding.md for what each knob does.
+# See docs/analysis_guide.md §17 for what each knob does and how to read the output.
 
 # ---------------------------------------------------------------------------
 # Data in: epochs file (high-gamma, rescaled) and the condition set.

--- a/docs/analysis_guide.md
+++ b/docs/analysis_guide.md
@@ -665,6 +665,7 @@ Path-level tests live under `tests/analysis/`:
 | `decoding/test_anova_electrode_selection_integration.py` | the real ANOVA selector on planted synthetic effects (marked `slow`) |
 | `decoding/test_cross_decoding_circularity.py` | A4's double-dipping guard |
 | `decoding/test_cross_decoding_electrode_groups.py` | A4's electrode groups incl. the unselected reference group (§17.1) |
+| `decoding/test_cross_decoding_condition_scheme.py` | A4's contrast/block definitions derived from the condition cells, and the real branch end to end (§17.2) |
 | `stats/test_stability_flexibility_anova_labels.py` | A1's four-interaction definition |
 | `stats/test_cmh_uninformative_strata.py` | the CMH empty-marginal fix (§14.5) |
 | `stats/test_stability_flexibility_timing.py` | A5, incl. the amplitude-invariance guard |
@@ -1831,16 +1832,21 @@ covers per group, so it has no separate code path.
 
 ### 17.1 Which electrodes are decoded
 
-Two independent choices, easy to conflate:
+Three independent choices, easy to conflate:
 
-1. **Which electrodes are loaded at all** — `ELECTRODES`. `sig` keeps the
-   baseline task-significant electrodes in the ROIs, `all` keeps every electrode
-   in them. (With `ROIS_DICT = None`, the current default, no ROI/significance
-   filter is applied and every channel is used.)
-2. **How those loaded electrodes are split for the decodes** — the groups.
+1. **Which region** — `ROI`, a key of `src/analysis/config/rois.py`
+   (`lpfc`, `acc`, `dlpfc`, `parietal`, `occ`, `v1`). Default `lpfc`.
+2. **Which of that region's electrodes are loaded at all** — `ELECTRODES`.
+   `sig` (default) keeps the baseline task-significant ones, `all` keeps every
+   electrode in the ROI.
+3. **How those loaded electrodes are split for the decodes** — the groups.
    `both`/`S_only`/`F_only` come from the interaction labels, and
    `REFERENCE_GROUP` (default `all`) adds the **unselected** set: every channel
    in the decoded ROI array.
+
+So "the `all` group" means *all the electrodes this run loaded* — with
+`ELECTRODES=sig` that is all baseline-significant electrodes in the ROI, with
+`ELECTRODES=all` it is every electrode in the ROI.
 
 The reference group matters because `both`, `S_only` and `F_only` were each
 *chosen* for carrying an interaction, so none of them is a baseline for "does
@@ -1852,7 +1858,40 @@ Temporal generalization costs `n_windows²` decodes per matrix, so it runs only 
 `TEMPGEN_GROUPS` (default `both`); use `TEMPGEN_GROUPS=both,all` to get the
 unselected comparison matrix too.
 
-### 17.2 Electrode definition: `anova` vs `power_traces`
+### 17.2 Conditions and contrasts — why the classes are derived, not written
+
+A4 needs the **full 2×2×2×2** condition set — every {congruency} × {incongruent
+proportion} × {switchType} × {switch proportion} cell — because it decodes one
+contrast, scores the other, and splits each by a block factor.
+`stimulus_experiment_conditions` is that set (16 conditions, `Stimulus_i75s25`
+and friends), and it is the `CONDITIONS` default.
+
+The class definitions are **derived from each condition's declared factor
+levels** (`cd.condition_cells`), not hand-written as substrings of the condition
+names. That is not fussiness: the Decoder matches classes by substring (§7), and
+the real and synthetic naming conventions collide —
+
+```
+real       Stimulus_{c|i}{25|75}{s|r}{25|75}            Stimulus_i75s25
+synthetic  Stimulus_{c|i}_{r|s}_{25|75}inc_{25|75}sw    Stimulus_i_s_75inc_25sw
+```
+
+`75s` means "switch trial in the 75%-incongruent block" in the first and
+"75%-switch block" in the second. Tokens that are right for one **silently decode
+the wrong contrast** on the other — no exception, just an answer to a different
+question (half the synthetic conditions get the wrong class from the real
+tokens; pinned by `test_cross_decoding_condition_scheme.py`). Since each
+condition already declares its levels, `cd.condition_cells` reads those and emits
+the class groups as full condition names, which no naming change can
+misinterpret. Swapping in a different condition dict works as long as its entries
+carry `congruency`, `switchType`, `incongruentProportion` and
+`switchProportion`.
+
+For the same reason `cd.filter_conditions` takes a *collection* of substrings,
+not just one: with the real naming, "the 25%-incongruent block" is the conditions
+matching `i25` **or** `c25`, which no single substring picks out.
+
+### 17.3 Electrode definition: `anova` vs `power_traces`
 
 `ELECTRODE_DEFINITION` picks how the S/F labels are derived. Both routes emit the
 same table (`CPC`/`SPS`/`CPS`/`SPC` + `S`/`F` aliases), so everything downstream
@@ -1877,57 +1916,117 @@ or one directory per interaction (`POWER_TRACES_CPC`, `POWER_TRACES_SPS`,
 needs), `cluster` (raw cluster p, matching the existing lab convention), or
 `none`.
 
-### 17.3 Scripts
+### 17.4 Scripts — how to run it
 
-`dcc_scripts/decoding`, prefix `stability_flexibility_cross_decoding`. The
-`anova` electrode definition still needs the long single-trial table
-(`effect_measure='cluster'`), so a real run assembles both; the `power_traces`
-route skips the long-table assembly entirely:
+`dcc_scripts/decoding`, prefix `stability_flexibility_cross_decoding`. Every knob
+below is settable from the environment, so no run needs a file edited; each is
+also commented where it is defined in
+`run_stability_flexibility_cross_decoding_dcc.py`, which is the file to read if
+you want to know what one does.
+
+**1. Sanity-check the pipeline first (~1 minute, no data needed).** The synthetic
+path plants a code with *known* ground truth, so it tells you the analysis can
+tell the two answers apart before you spend cluster time:
 
 ```bash
 cd dcc_scripts/decoding
-# validate the discrimination in ~a minute with a PLANTED shared code (should transfer):
-DATA_SOURCE=synthetic SYNTHETIC_CODE=shared bash submit_stability_flexibility_cross_decoding_dcc.sh
-# the ORTHOGONAL code (each contrast decodable, but should NOT cross-decode):
-DATA_SOURCE=synthetic SYNTHETIC_CODE=orthogonal bash submit_stability_flexibility_cross_decoding_dcc.sh
-# real run — set EPOCHS_ROOT_FILE in the submit script, then:
-bash submit_stability_flexibility_cross_decoding_dcc.sh
-# sweep the train/test proportion (StratifiedShuffleSplit instead of StratifiedKFold):
-FRAC_TRAIN=0.5 bash submit_stability_flexibility_cross_decoding_dcc.sh
 
-# no SLURM, fast local sanity check:
+# a SHARED code — label transfer SHOULD come out above chance
 DATA_SOURCE=synthetic SYNTHETIC_CODE=shared \
+    WINDOW_SIZE=16 STEP_SIZE=16 N_SPLITS=3 N_REPEATS=2 N_PERM=50 \
+    python run_stability_flexibility_cross_decoding_dcc.py
+
+# an ORTHOGONAL code — each contrast decodable, transfer should be AT chance
+DATA_SOURCE=synthetic SYNTHETIC_CODE=orthogonal \
     WINDOW_SIZE=16 STEP_SIZE=16 N_SPLITS=3 N_REPEATS=2 N_PERM=50 \
     python run_stability_flexibility_cross_decoding_dcc.py
 ```
 
-The hyperparameters are the **ordinary decoding ones**:
+If `shared` transfers and `orthogonal` doesn't, the machinery works and a null
+result on real data means something.
+
+**2. The real run.**
+
+```bash
+EPOCHS_ROOT_FILE=Stimulus_-1.0to1.5sec_..._nan_policy_omit \
+    bash submit_stability_flexibility_cross_decoding_dcc.sh
+```
+
+Everything else has a working default: `ROI=lpfc`, `ELECTRODES=sig`,
+`CONDITIONS=stimulus_experiment_conditions`, window `[0.0, 0.5]s`,
+`ELECTRODE_DEFINITION=anova`. The `anova` definition needs the long single-trial
+table (`effect_measure='cluster'`), so a real run assembles both; the
+`power_traces` route skips the long-table assembly entirely.
+
+**3. What you'd usually tweak, in order of how often.**
+
+| Want to… | Set |
+|---|---|
+| decode a different region | `ROI=acc` (keys of `src/analysis/config/rois.py`) |
+| use every electrode, not just baseline-significant ones | `ELECTRODES=all` |
+| move the definition window | `WINDOW_TMIN=0.2 WINDOW_TMAX=0.7` |
+| define electrodes from the power-trace runs instead | `ELECTRODE_DEFINITION=power_traces POWER_TRACES_RUN_DIR=...` (§17.3) |
+| get the unselected temporal-generalization matrix too | `TEMPGEN_GROUPS=both,all` |
+| make it finish faster (at the cost of precision) | `N_REPEATS=5 N_PERM=200 STEP_SIZE=20` |
+| sweep the train/test proportion | `FRAC_TRAIN=0.5` (StratifiedShuffleSplit instead of StratifiedKFold) |
+
+**4. Reading the output.** Start with `summary.txt`. The one number that answers
+the question is `n_sig_windows` for **label transfer on the `both` group** — not
+any single window's accuracy, since the verdict is cluster-corrected across time.
+Compare against the `all` (reference) group in the same table: it is every
+electrode in the ROI, selected by nothing, so it says what the region does before
+any interaction-based selection (§17.1).
+
+**All knobs.** Grouped by what each group controls.
+
+*What data goes in*
 
 | Variable | Default | Meaning |
 |---|---|---|
+| `EPOCHS_ROOT_FILE` | *required for real runs* | which epoched dataset to load. |
 | `DATA_SOURCE` | `real` | `real` = epoched data; `synthetic` = ground-truth dry run. |
 | `SYNTHETIC_CODE` | `shared` | synthetic only: `shared` (should cross-decode) or `orthogonal` (should not). |
-| `WINDOW_TMIN` / `WINDOW_TMAX` | `0.0` / `0.5` | analysis window for the A1 definition. |
-| `ELECTRODES` | `all` | `all` or `sig` (baseline task-significant) — which electrodes are **loaded** (§17.1). |
-| `ROI` | `all` | which ROI's LabeledArray to decode. |
-| `ALPHA` | `0.05` | A1 FDR threshold for the electrode groups. |
-| `ELECTRODE_DEFINITION` | `anova` | `anova` (in-job window-mean ANOVA) or `power_traces` (finished cluster-corrected runs) — §17.2. |
+| `CONDITIONS` | `stimulus_experiment_conditions` | name of a dict in `config/experiment_conditions.py`. Must carry the full 2×2×2×2 (§17.2). |
+
+*Which electrodes* (§17.1)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `ROI` | `lpfc` | which region to decode — a key of `config/rois.py`. |
+| `ELECTRODES` | `sig` | `sig` (baseline task-significant) or `all` — which of the ROI's electrodes are **loaded**. |
+| `REFERENCE_GROUP` | `all` | name of the unselected all-electrode group; `''` drops it. |
+| `MIN_GROUP_SIZE` | `5` | skip electrode groups too small to decode. |
+
+*How the S/F electrode groups are defined* (§17.3)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `ELECTRODE_DEFINITION` | `anova` | `anova` (in-job window-mean ANOVA) or `power_traces` (finished cluster-corrected runs). |
+| `WINDOW_TMIN` / `WINDOW_TMAX` | `0.0` / `0.5` | `anova` only: definition window, in seconds from stimulus onset. |
+| `ALPHA` | `0.05` | FDR threshold for the electrode groups. |
 | `POWER_TRACES_RUN_DIR` | unset | `power_traces` only: one run carrying all four interactions. |
 | `POWER_TRACES_CPC` / `_SPS` / `_CPS` / `_SPC` | unset | `power_traces` only: one run directory per interaction (overrides the single-run form). |
 | `POWER_TRACES_CORRECTION` | `fdr_bh` | `fdr_bh`, `cluster`, or `none`. |
 | `POWER_TRACES_ROI` | unset | `power_traces` only: restrict the labels to one ROI. |
-| `REFERENCE_GROUP` | `all` | name of the unselected all-electrode group; `''` drops it (§17.1). |
-| `TEMPGEN_GROUPS` | `both` | comma-separated groups to run temporal generalization on; `''` skips it. |
-| `WINDOW_SIZE` / `STEP_SIZE` | `20` / `10` | decoding window and stride, in samples. |
+
+*Decoding hyperparameters* — the **ordinary decoding ones** (§7)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `WINDOW_SIZE` / `STEP_SIZE` | `20` / `10` | decoding window and stride, in samples. Bigger stride = fewer windows = faster. |
 | `N_SPLITS` | `5` | CV folds — or random resamples per repeat when `FRAC_TRAIN` is set. |
-| `N_REPEATS` | `10` | CV repeats. |
+| `N_REPEATS` | `10` | CV repeats. The main runtime lever. |
 | `FRAC_TRAIN` | unset | **proportion of trials used for training.** Unset keeps `StratifiedKFold` at `(N_SPLITS-1)/N_SPLITS`; setting it switches to `StratifiedShuffleSplit` at exactly this fraction. |
 | `EXPLAINED_VARIANCE` | `0.8` | PCA variance retained. |
 | `N_PERM` | `500` | permutations for the cluster test over windows. |
-| `MIN_GROUP_SIZE` | `5` | skip electrode groups too small to decode. |
+| `TEMPGEN_GROUPS` | `both` | comma-separated groups to run temporal generalization on; `''` skips it. Each matrix costs `n_windows²` decodes. |
+| `SEED` | `0` | random seed. |
+| `SAVE_DIR` | derived | override the output directory. |
 
 **Outputs** →
-`results/<epochs_or_synthetic_tag>/cross_decoding_window_<tmin>to<tmax>s_<electrodes>/`:
+`results/<epochs_or_synthetic_tag>/cross_decoding_<roi>_window_<tmin>to<tmax>s_<electrodes>_<definition>/`
+— the ROI, electrode set and definition route are all in the path, so runs that
+differ in any of them don't overwrite each other:
 
 - `cross_decoding.json` — per design/group: mean and peak accuracy, shuffle mean,
   number of cluster-significant windows (bulky arrays stripped).

--- a/src/analysis/decoding/cross_decoding.py
+++ b/src/analysis/decoding/cross_decoding.py
@@ -90,6 +90,136 @@ def resolve_contrast(contrast):
 
 
 # ---------------------------------------------------------------------------
+# condition cells -> the class groups `build_cross_decoding_arrays` wants
+# ---------------------------------------------------------------------------
+# The Decoder identifies classes by SUBSTRINGS of the condition name, which makes
+# the class definitions a hostage to the naming convention. The two conventions
+# in play here really do collide:
+#
+#   real (`experiment_conditions.stimulus_experiment_conditions`)
+#       Stimulus_{c|i}{25|75}{s|r}{25|75}      e.g. Stimulus_i25s75
+#   synthetic (`synthetic_roi_labeled_arrays`)
+#       Stimulus_{c|i}_{r|s}_{25|75}inc_{25|75}sw   e.g. Stimulus_i_s_25inc_75sw
+#
+# '75s' means "switch trial in the 75%-incongruent block" in the first and
+# "75%-switch block" in the second, so ONE hand-written substring set cannot
+# serve both -- and getting it wrong does not raise, it silently decodes the
+# wrong contrast.
+#
+# So don't parse names at all. Each condition already declares its factor levels
+# (the real conditions in their config entry, the synthetic ones via
+# `synthetic_condition_cells`); read those, and emit the class groups as the FULL
+# condition names belonging to each level. A full name is trivially a substring
+# of itself, so the existing substring machinery works unchanged and no collision
+# is possible.
+CELL_FIELDS = ("congruency", "switchType",
+               "incongruent_proportion", "switch_proportion")
+
+# The config spells the proportions in camelCase; the long-table / stats side of
+# the project uses snake_case. Accept either so a condition dict from either
+# convention drops in.
+_FIELD_ALIASES = {
+    "congruency": ("congruency",),
+    "switchType": ("switchType", "switch_type", "task_sequence"),
+    "incongruent_proportion": ("incongruentProportion", "incongruent_proportion"),
+    "switch_proportion": ("switchProportion", "switch_proportion"),
+}
+
+
+def _as_proportion(value):
+    """'25%' / '25' / 25.0 / 25 -> 25 (int). None if it isn't a proportion."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.strip().rstrip('%')
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def condition_cells(conditions):
+    """`{condition_name: {field: level}}` from an `experiment_conditions`-style dict.
+
+    `conditions` maps condition name -> its metadata entry (the same dict the
+    decoding pipeline is driven by, e.g.
+    ``experiment_conditions.stimulus_experiment_conditions``). Conditions that do
+    not declare all four factors are dropped: a cross-decode needs every cell of
+    the 2x2x2x2, and a partially-specified condition cannot be placed in it.
+    """
+    cells = {}
+    for name, meta in conditions.items():
+        if not isinstance(meta, dict):
+            continue
+        cell = {}
+        for field, aliases in _FIELD_ALIASES.items():
+            value = next((meta[a] for a in aliases if a in meta), None)
+            if field.endswith('proportion'):
+                value = _as_proportion(value)
+            cell[field] = value
+        if any(v is None for v in cell.values()):
+            continue                       # not a full 4-factor cell
+        cells[name] = cell
+    if not cells:
+        raise ValueError(
+            "no condition declares all of "
+            f"{CELL_FIELDS}; a cross-decode needs the full 2x2x2x2 condition set "
+            "(e.g. experiment_conditions.stimulus_experiment_conditions)")
+    return cells
+
+
+def class_strings(cells, field, pos, neg):
+    """Class groups (`[[pos names], [neg names]]`) for one factor of the cells.
+
+    Emitted as full condition names rather than shorthand substrings, so the
+    grouping is exactly the factor level the condition declared.
+    """
+    groups = []
+    for level in (pos, neg):
+        names = sorted(n for n, c in cells.items() if c[field] == level)
+        if not names:
+            raise ValueError(
+                f"no condition has {field}={level!r}; "
+                f"levels present: {sorted({c[field] for c in cells.values()})}")
+        groups.append(names)
+    return groups
+
+
+def stability_flexibility_strings(cells):
+    """The two contrasts A4 transfers between: (congruency i-vs-c, switch s-vs-r)."""
+    return (class_strings(cells, 'congruency', 'i', 'c'),
+            class_strings(cells, 'switchType', 's', 'r'))
+
+
+def block_condition_sets(cells, field):
+    """`{level: [condition names]}` for a block factor, low level first.
+
+    Feeds the within-block designs: "decode a contrast inside one block level" is
+    `filter_conditions(..., block_condition_sets(cells, field)[level])`.
+    """
+    levels = sorted({c[field] for c in cells.values()})
+    return {level: sorted(n for n, c in cells.items() if c[field] == level)
+            for level in levels}
+
+
+def synthetic_condition_cells(**kwargs):
+    """The `condition_cells` table for `synthetic_roi_labeled_arrays`' conditions.
+
+    Kept next to the generator so the two can never drift: both build the same
+    names from the same nested loop.
+    """
+    cells = {}
+    for cong in ("c", "i"):
+        for sw in ("r", "s"):
+            for inc_prop in (25, 75):
+                for sw_prop in (25, 75):
+                    cells[f"Stimulus_{cong}_{sw}_{inc_prop}inc_{sw_prop}sw"] = dict(
+                        congruency=cong, switchType=sw,
+                        incongruent_proportion=inc_prop, switch_proportion=sw_prop)
+    return cells
+
+
+# ---------------------------------------------------------------------------
 # Double-dipping guard for the electrode-definition <-> decode diagonal
 # ---------------------------------------------------------------------------
 # Electrodes are defined by one of the FOUR two-way interactions
@@ -241,8 +371,14 @@ def build_cross_decoding_arrays(roi_labeled_arrays, roi, train_strings,
     )
 
 
-def filter_conditions(roi_labeled_arrays, roi, keep_substring, new_roi=None):
-    """Keep only the conditions whose name contains `keep_substring`.
+def filter_conditions(roi_labeled_arrays, roi, keep, new_roi=None):
+    """Keep only the conditions matching `keep`.
+
+    `keep` is one substring, or a collection of them — a condition is kept if ANY
+    matches. The collection form is what `block_condition_sets` returns (full
+    condition names), and it is what a real block level NEEDS: with the real
+    naming, "the 25%-incongruent block" is the conditions matching `i25` OR `c25`,
+    which no single substring picks out.
 
     How the within-block 2x2 (Design 0 / Fig 9) is expressed: decoding a contrast
     *within one block level* is just an ordinary decode over that block's
@@ -250,15 +386,16 @@ def filter_conditions(roi_labeled_arrays, roi, keep_substring, new_roi=None):
     contrast for train and test. Comparing the two block levels' accuracies is the
     decoding analogue of the univariate LWPC / LWPS effect.
 
-    Returns a `{roi: {condition: array}}` dict ready to pass back in. Raises if the
-    substring matches nothing, since a silently empty ROI would look like a failed
-    decode rather than a bad filter.
+    Returns a `{roi: {condition: array}}` dict ready to pass back in. Raises if
+    nothing matches, since a silently empty ROI would look like a failed decode
+    rather than a bad filter.
     """
+    wanted = [keep] if isinstance(keep, str) else list(keep)
     kept = {name: arr for name, arr in roi_labeled_arrays[roi].items()
-            if keep_substring in name}
+            if any(w in name for w in wanted)}
     if not kept:
         raise ValueError(
-            f"no condition in ROI {roi!r} contains {keep_substring!r}; "
+            f"no condition in ROI {roi!r} matches {wanted!r}; "
             f"have {sorted(roi_labeled_arrays[roi].keys())[:6]}...")
     return {new_roi or roi: kept}
 

--- a/tests/analysis/decoding/test_cross_decoding_condition_scheme.py
+++ b/tests/analysis/decoding/test_cross_decoding_condition_scheme.py
@@ -1,0 +1,201 @@
+"""Contrast + block definitions for the A4 cross-decoding job.
+
+The Decoder identifies classes by SUBSTRINGS of the condition name, and the two
+naming conventions in this project collide on the obvious shorthand:
+
+    real       Stimulus_{c|i}{25|75}{s|r}{25|75}            Stimulus_i75s25
+    synthetic  Stimulus_{c|i}_{r|s}_{25|75}inc_{25|75}sw    Stimulus_i_s_75inc_25sw
+
+'75s' is "switch trial in the 75%-incongruent block" in the first and "75%-switch
+block" in the second. A hand-written token set that is right for one silently
+decodes the WRONG contrast on the other — no exception, just an answer to a
+different question. So the class groups are derived from each condition's
+declared factor levels instead, and these tests pin that down.
+
+The final test runs the real branch of `main()` end to end over real condition
+names, with only the epoch loading and the electrode definition stubbed.
+"""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.analysis.config import experiment_conditions as ec
+from src.analysis.decoding import cross_decoding as cd
+from dcc_scripts.decoding import stability_flexibility_cross_decoding_dcc as xd
+
+
+@pytest.fixture(scope="module")
+def real_cells():
+    return cd.condition_cells(ec.stimulus_experiment_conditions)
+
+
+# ---------------------------------------------------------------------------
+# cells
+# ---------------------------------------------------------------------------
+def test_real_conditions_are_the_full_2x2x2x2(real_cells):
+    assert len(real_cells) == 16
+    for field, levels in (('congruency', {'i', 'c'}), ('switchType', {'s', 'r'}),
+                          ('incongruent_proportion', {25, 75}),
+                          ('switch_proportion', {25, 75})):
+        assert {c[field] for c in real_cells.values()} == levels
+
+
+def test_camelcase_proportions_are_normalised(real_cells):
+    # the config spells these 'incongruentProportion': '25%'
+    assert all(isinstance(c['incongruent_proportion'], int)
+               for c in real_cells.values())
+
+
+def test_partial_conditions_are_dropped():
+    """A condition missing a factor cannot be placed in the 2x2x2x2."""
+    conditions = dict(ec.stimulus_experiment_conditions)
+    conditions['Stimulus_partial'] = {'BIDS_events': ['Stimulus'], 'congruency': 'i'}
+    assert 'Stimulus_partial' not in cd.condition_cells(conditions)
+
+
+def test_a_condition_set_without_the_four_factors_raises():
+    with pytest.raises(ValueError, match='full 2x2x2x2'):
+        cd.condition_cells(ec.stimulus_congruency_conditions)
+
+
+# ---------------------------------------------------------------------------
+# contrasts
+# ---------------------------------------------------------------------------
+def test_every_condition_is_labelled_by_both_contrasts(real_cells):
+    """A cross-decode drops any condition only one contrast can label."""
+    stab, flex = cd.stability_flexibility_strings(real_cells)
+    for name in real_cells:
+        assert cd._class_of(name, stab) is not None, name
+        assert cd._class_of(name, flex) is not None, name
+
+
+def test_contrast_classes_match_the_declared_levels(real_cells):
+    stab, flex = cd.stability_flexibility_strings(real_cells)
+    for name, cell in real_cells.items():
+        assert cd._class_of(name, stab) == (0 if cell['congruency'] == 'i' else 1)
+        assert cd._class_of(name, flex) == (0 if cell['switchType'] == 's' else 1)
+
+
+def test_the_two_conventions_really_do_collide():
+    """Why the classes are derived rather than hand-written: tokens that are
+    correct for the real names mislabel half the synthetic ones."""
+    syn = cd.synthetic_condition_cells()
+    _, syn_flex = cd.stability_flexibility_strings(syn)
+    real_tokens = [['25s', '75s'], ['25r', '75r']]     # right for Stimulus_i25s75
+    wrong = [n for n in syn
+             if cd._class_of(n, real_tokens) != cd._class_of(n, syn_flex)]
+    assert len(wrong) == len(syn) // 2
+
+
+def test_synthetic_cells_match_the_generator_condition_names():
+    arrays = cd.synthetic_roi_labeled_arrays(seed=0)
+    assert set(cd.synthetic_condition_cells()) == set(arrays['synthetic'])
+
+
+# ---------------------------------------------------------------------------
+# block sets
+# ---------------------------------------------------------------------------
+def test_block_sets_split_the_conditions_in_half(real_cells):
+    for field in ('incongruent_proportion', 'switch_proportion'):
+        sets = cd.block_condition_sets(real_cells, field)
+        assert list(sets) == [25, 75]            # low level first
+        assert all(len(v) == 8 for v in sets.values())
+        assert not set(sets[25]) & set(sets[75])
+
+
+def test_a_real_block_level_needs_more_than_one_substring(real_cells):
+    """The 25%-incongruent block is `i25` OR `c25` — no single substring gets it,
+    which is why `filter_conditions` takes a collection."""
+    low = cd.block_condition_sets(real_cells, 'incongruent_proportion')[25]
+    assert not any(all(tok in n for n in low) for tok in ('i25', 'c25'))
+
+    arrays = {'roi': {n: np.zeros((4, 2, 3)) for n in real_cells}}
+    kept = cd.filter_conditions(arrays, 'roi', low)['roi']
+    assert set(kept) == set(low)
+
+
+def test_filter_conditions_still_takes_a_bare_substring(real_cells):
+    arrays = {'roi': {n: np.zeros((4, 2, 3)) for n in real_cells}}
+    kept = cd.filter_conditions(arrays, 'roi', 'i25')['roi']
+    assert set(kept) == {n for n, c in real_cells.items()
+                         if c['congruency'] == 'i' and c['incongruent_proportion'] == 25}
+
+
+def test_filter_conditions_raises_rather_than_returning_empty(real_cells):
+    arrays = {'roi': {n: np.zeros((4, 2, 3)) for n in real_cells}}
+    with pytest.raises(ValueError, match='no condition'):
+        cd.filter_conditions(arrays, 'roi', ['nope'])
+
+
+# ---------------------------------------------------------------------------
+# the real branch, end to end
+# ---------------------------------------------------------------------------
+def _fake_roi_arrays(cells, n_channels=8, n_trials=24, n_time=16, seed=0):
+    """A pseudopopulation keyed by the REAL condition names, with a shared code
+    (congruency and switchType on the same axis) so the decodes have signal."""
+    rng = np.random.default_rng(seed)
+    axis = rng.normal(size=n_channels)
+    axis /= np.linalg.norm(axis)
+    arrays = {}
+    for name, cell in cells.items():
+        x = rng.normal(0, 1.0, (n_trials, n_channels, n_time))
+        gain = 1.2 * ((cell['congruency'] == 'i') + (cell['switchType'] == 's'))
+        x += (gain * axis)[None, :, None]
+        arrays[name] = x
+    return arrays
+
+
+def test_real_branch_runs_over_real_condition_names(tmp_path, monkeypatch):
+    cells = cd.condition_cells(ec.stimulus_experiment_conditions)
+    channel_names = [f'D{i // 4}-E{i % 4}' for i in range(8)]
+    arrays = {'lpfc': _fake_roi_arrays(cells)}
+
+    labels = pd.DataFrame(dict(
+        subject=[c.split('-')[0] for c in channel_names],
+        electrode=channel_names,
+        S=[1, 1, 1, 0, 1, 1, 0, 0], F=[1, 1, 1, 1, 0, 0, 1, 0],
+        CPC=[1, 1, 1, 0, 1, 1, 0, 0], SPS=[1, 1, 1, 1, 0, 0, 1, 0],
+        CPS=[0, 0, 0, 0, 0, 0, 0, 0], SPC=[0, 0, 0, 0, 0, 0, 0, 0]))
+
+    # stub out only the two things that need the cluster's data
+    monkeypatch.setattr(xd, '_resolve_labels', lambda args, df=None: labels)
+    monkeypatch.setattr(xd, '_build_roi_arrays',
+                        lambda args, lab_root: ('lpfc', arrays, channel_names, cells))
+    monkeypatch.setattr('src.analysis.utils.general_utils.resolve_lab_root',
+                        lambda explicit=None: '/nonexistent')
+
+    args = SimpleNamespace(
+        data_source='real', synthetic_code=None, LAB_root=None, subjects=[],
+        task='GlobalLocal', acc_trials_only=True, epochs_root_file='epochs',
+        window_tmin=0.0, window_tmax=0.5, conditions=ec.stimulus_experiment_conditions,
+        electrodes='sig', rois_dict={'lpfc': []}, alpha=0.05, roi='lpfc',
+        electrode_definition='power_traces', power_traces_runs='run',
+        power_traces_correction='fdr_bh', power_traces_roi=None,
+        reference_group='all', tempgen_groups=(),
+        window_size=8, step_size=8, n_splits=3, n_repeats=2,
+        explained_variance=0.8, frac_train=None, n_perm=10, min_group_size=2,
+        seed=0, save_dir=str(tmp_path))
+    results = xd.main(args)
+
+    # both contrasts decoded within both levels of their own block factor
+    wb = results['within_block']
+    assert set(wb) == {'congruency (LWPC)', 'switchType (LWPS)'}
+    assert set(wb['congruency (LWPC)']['per_block']) == {'25% incongruent',
+                                                         '75% incongruent'}
+    assert set(wb['switchType (LWPS)']['per_block']) == {'25% switch', '75% switch'}
+    assert wb['congruency (LWPC)']['block_difference'] is not None
+
+    # the reference group is decoded alongside the selected ones
+    assert 'all' in results['label_transfer']
+    assert results['label_transfer']['all']['stab_to_flex']['n_channels'] == 8
+
+    # the double-dip diagonal is still skipped per interaction group
+    for gflag, res in results['within_block_by_group'].items():
+        diag = cd.circular_decode_for_group(gflag)
+        assert not any(f'{diag[0]} by {diag[1]}' in cell for cell in res['cells'])
+
+    assert (tmp_path / 'cross_decoding.json').exists()
+    assert (tmp_path / 'summary.txt').exists()


### PR DESCRIPTION
… to run it

The real branch had never been executed end to end. Two blockers:

1. main() read args.subjects_mne_objects / .condition_names / .electrodes_per_subject_roi / .roi_channel_names, none of which the runner ever set — AttributeError right after the electrode definition. Added _build_roi_arrays(), mirroring decoding_dcc.main()'s setup: same ROI/significance electrode resolution, the same filter against what survived epoching, the same pseudopopulation builder. Channel names now come from the array's own labelling rather than a phantom arg.

2. The contrast and block tokens ('_i_', '_c_', '25inc', ...) matched the SYNTHETIC condition names only. Real conditions are Stimulus_{c|i}{25|75}{s|r}{25|75}, so filter_conditions would have raised on every block level — and worse, the two conventions collide: '75s' is "switch trial in the 75%-incongruent block" for real names and "75%-switch block" for synthetic ones, so a token set that is right for one silently decodes the wrong contrast on the other (verified: half the synthetic conditions get the wrong class from the real tokens).

   So stop parsing names. Each condition already declares its factor levels, so cd.condition_cells reads those and emits the class groups as full condition names, which the existing substring machinery handles and no naming change can misinterpret. filter_conditions now takes a collection too, which a real block level needs (the 25%-incongruent block is `i25` OR `c25` — no single substring gets it).

Runner wiring: CONDITIONS (default stimulus_experiment_conditions, the full 2x2x2x2 A4 needs), ROI defaulting to lpfc off config/rois.py with a clear error for an unknown key, ELECTRODES defaulting to 'sig'. The ROI, electrode set and definition route are now in the output path so runs that differ in any of them stop overwriting each other.

Verified end to end: the synthetic ground truth still discriminates (shared transfers at .62 vs .50 shuffle; orthogonal sits at chance), and a new integration test drives the real branch over real condition names with only epoch loading and the electrode definition stubbed.

Docs: the README leads with how to run it — sanity-check on synthetic, then the real run, then a table of what you'd usually tweak and how to read the output — and the knob table is grouped by what each group controls. The submit script exposes every knob via the environment with comments, so no run needs the file edited.


Claude-Session: https://claude.ai/code/session_01HtjJ177NA9SNYBbUx4yyjL