### PR TITLE
Allow the cross-decode to run on the proportion-pooled 2x2 condition set

### DIFF
--- a/dcc_scripts/decoding/run_stability_flexibility_cross_decoding_dcc.py
+++ b/dcc_scripts/decoding/run_stability_flexibility_cross_decoding_dcc.py
@@ -70,13 +70,26 @@ WINDOW_TMIN = float(os.environ.get('WINDOW_TMIN', '0.0'))   # seconds post-stimu
 WINDOW_TMAX = float(os.environ.get('WINDOW_TMAX', '0.5'))
 
 # --- conditions ---
-# A4 transfers a classifier between congruency and switchType, and splits each by
-# a block proportion, so it needs the FULL 2x2x2x2 condition set — every
-# {congruency} x {incongruent proportion} x {switchType} x {switch proportion}
-# cell. `stimulus_experiment_conditions` is that set. The contrast and block
-# definitions are read off each condition's declared factor levels, so swapping
-# in another condition dict works as long as its entries carry `congruency`,
-# `switchType`, `incongruentProportion` and `switchProportion`.
+# A4 transfers a classifier between congruency and switchType, so a condition
+# must declare BOTH on the same cell — that is the only hard requirement. Two
+# sets are useful, chosen with CONDITIONS=<name>:
+#
+#   stimulus_experiment_conditions   (default) the full 2x2x2x2, 16 cells. Needed
+#       for the within-block designs A4(0)/A4(0b), and it stratifies the CV folds
+#       on all four factors, so a fold can never be lopsided on a proportion.
+#   stimulus_main_effect_conditions  the pooled 2x2 (Stimulus_i{r,s}/c{r,s}), 4
+#       cells collapsing BOTH proportions — "ALL congruency vs ALL switch type"
+#       with ~4x the trials per cell, hence less NaN padding / mixup in the
+#       pseudopopulation. A4(0)/A4(0b) are skipped (no block factor to split on);
+#       label transfer A4(a) and temporal generalization A4(c) run unchanged.
+#
+# Note A4(a) is pooled over the proportions under EITHER set: its classes are
+# every 'i' cell vs every 'c' cell. The 16-cell set does not restrict the
+# transfer to within a block — only designs (0)/(0b) split by block.
+#
+# Condition sets carrying just one factor (stimulus_congruency_conditions,
+# stimulus_switch_type_conditions) cannot be used: the two labellings would come
+# from separate epoch sets over the same trials, so train and test would overlap.
 CONDITIONS = getattr(experiment_conditions,
                      os.environ.get('CONDITIONS', 'stimulus_experiment_conditions'))
 

--- a/dcc_scripts/decoding/stability_flexibility_cross_decoding_dcc.py
+++ b/dcc_scripts/decoding/stability_flexibility_cross_decoding_dcc.py
@@ -27,6 +27,9 @@ Designs:
       reference group (`args.reference_group`, default 'all' = every electrode in
       the decoded ROI array). Prediction: only 'both' cross-decodes; the
       reference group says what the region does before any selection.
+      This design is ALREADY pooled: its classes are every 'i' cell vs every 'c'
+      cell and every 's' cell vs every 'r' cell, across both block proportions.
+      Only design (0)/(0b) splits by proportion.
   (c) temporal generalization (Fig 10): train-window × test-window accuracy
       matrix, within a contrast and across contrasts, on `args.tempgen_groups`
       (default: the 'both' group).
@@ -38,6 +41,13 @@ this job, 'power_traces' reads the finished cluster-corrected windowed-ANOVA run
 Contrast and block definitions are read off each condition's declared factor
 levels (`cd.condition_cells`), not parsed out of condition names — the real and
 synthetic naming conventions collide on the obvious shorthand tokens.
+
+A condition set only has to declare congruency AND switchType on the same
+condition. With the full 2x2x2x2 (`stimulus_experiment_conditions`, the default)
+every design above runs. With the pooled 2x2 (`stimulus_main_effect_conditions`,
+which collapses both proportions into 4 cells and so puts ~4x the trials in each)
+designs (a) and (c) run unchanged over more trials per cell, and (0)/(0b) are
+skipped — see `cd.has_block_factor`.
 
 Design (b) "set comparison" is just the same contrast decoded within each
 electrode set — an ordinary decode with `electrodes` restricted — and is covered
@@ -504,7 +514,7 @@ def _build_roi_arrays(args, LAB_root):
 
     cells = cd.condition_cells(args.conditions)
     condition_names = list(cells)
-    print(f"conditions: {len(condition_names)} full 2x2x2x2 cells "
+    print(f"conditions: {len(condition_names)} decodable cells "
           f"(of {len(args.conditions)} in the condition set)")
 
     subjects_mne_objects = create_subjects_mne_objects_dict(
@@ -621,10 +631,21 @@ def main(args):
     # Contrasts and block sets, read off each condition's declared factor levels
     # rather than parsed out of its name (see `cd.condition_cells`).
     stab_strings, flex_strings = cd.stability_flexibility_strings(cells)
-    blocks = {'incongruent_proportion': cd.block_condition_sets(cells, 'incongruent_proportion'),
-              'switch_proportion': cd.block_condition_sets(cells, 'switch_proportion')}
-    print("block levels: "
-          + "  ".join(f"{f}={sorted(levels)}" for f, levels in blocks.items()))
+    # A condition set that POOLS over a proportion (e.g.
+    # `stimulus_main_effect_conditions`, the 2x2 for the all-vs-all transfer) has
+    # no block contrast to make, so the block-split designs below are skipped
+    # rather than run on a constant. Label transfer and temporal generalization
+    # are unaffected: they never split by block in the first place.
+    blocks = {f: cd.block_condition_sets(cells, f)
+              for f in ('incongruent_proportion', 'switch_proportion')
+              if cd.has_block_factor(cells, f)}
+    if blocks:
+        print("block levels: "
+              + "  ".join(f"{f}={sorted(levels)}" for f, levels in blocks.items()))
+    else:
+        print("block levels: none — the condition set pools over both proportions, "
+              "so the within-block designs A4(0)/A4(0b) are skipped and only the "
+              "pooled label transfer / temporal generalization run")
 
     results = {}
 
@@ -636,6 +657,9 @@ def main(args):
     for cname, strings, block_col in (
             ('congruency (LWPC)', stab_strings, 'incongruent_proportion'),
             ('switchType (LWPS)', flex_strings, 'switch_proportion')):
+        if block_col not in blocks:
+            print(f"     skipping {cname}: the condition set pools over {block_col}")
+            continue
         per_block = {}
         for level, conds in blocks[block_col].items():
             tag = f'{level}% {_BLOCK_TAG[block_col]}'
@@ -662,12 +686,15 @@ def main(args):
     #     cells, never on congruency/inc_prop (the interaction that defined it).
     #     To keep the diagonal cell instead, define the electrodes on a disjoint
     #     set of trials (`trial_splitting.apply_electrode_definition_split`).
-    if interaction_groups:
+    if interaction_groups and blocks:
         print("A4(0b): per-group within-block 2x2 (diagonal define==decode cells ignored)")
-        decode_cells = [('congruency', 'incongruent_proportion', stab_strings),
-                        ('congruency', 'switch_proportion', stab_strings),
-                        ('switchType', 'switch_proportion', flex_strings),
-                        ('switchType', 'incongruent_proportion', flex_strings)]
+        decode_cells = [(contrast, block_col, strings)
+                        for contrast, block_col, strings in (
+                            ('congruency', 'incongruent_proportion', stab_strings),
+                            ('congruency', 'switch_proportion', stab_strings),
+                            ('switchType', 'switch_proportion', flex_strings),
+                            ('switchType', 'incongruent_proportion', flex_strings))
+                        if block_col in blocks]
         per_group = {}
         for gflag, elset in interaction_groups.items():
             restricted, n_kept = _restrict_to_electrodes(arrays, roi, channel_names, elset)

--- a/docs/analysis_guide.md
+++ b/docs/analysis_guide.md
@@ -1797,7 +1797,10 @@ the contrast you *score*.
 - **(a) Label transfer.** Train on stability, test on flexibility (and vice
   versa), on the *same* electrodes, separately per `both`/`S_only`/`F_only`
   group, **plus the unselected reference group** (`REFERENCE_GROUP`, default
-  `all` — see §17.1). Prediction: only the `both` group cross-decodes.
+  `all` — see §17.1). Prediction: only the `both` group cross-decodes. This is
+  the **all-vs-all** decode: its classes span every condition cell, so it is
+  already pooled across both block proportions (§17.2) — only (0)/(0b) split by
+  block.
 - **(c) Temporal generalization (Fig 10).** Train at *t*, test at *t′* →
   off-diagonal generalization = sustained/stable code, narrow diagonal =
   moving/phasic code. `cv_cm_jim_window_shuffle(..., temporal_generalization=True)`.
@@ -1860,11 +1863,34 @@ unselected comparison matrix too.
 
 ### 17.2 Conditions and contrasts — why the classes are derived, not written
 
-A4 needs the **full 2×2×2×2** condition set — every {congruency} × {incongruent
-proportion} × {switchType} × {switch proportion} cell — because it decodes one
-contrast, scores the other, and splits each by a block factor.
-`stimulus_experiment_conditions` is that set (16 conditions, `Stimulus_i75s25`
-and friends), and it is the `CONDITIONS` default.
+**The transfer is already pooled over the proportions.** Design (a)'s classes are
+*every* `i` cell vs *every* `c` cell and *every* `s` cell vs *every* `r` cell, so
+it is the ALL-congruency vs ALL-switchType decode over all trials. Using the
+16-cell condition set does **not** run the transfer inside a block — only designs
+(0)/(0b) split by block, and comparing their two block levels' accuracies is what
+makes them the decoding analogue of LWPC / LWPS.
+
+A condition must declare `congruency` **and** `switchType` on the same cell —
+that is the only hard requirement, because a transfer needs both labellings of
+the *same trial*. Two sets are useful (`CONDITIONS=<name>`):
+
+| `CONDITIONS` | Cells | Designs that run | Why pick it |
+|---|---|---|---|
+| `stimulus_experiment_conditions` (default) | 16 — the full 2×2×2×2 | all of (0), (0b), (a), (c) | the only set that supports the within-block designs; also stratifies the CV folds on **all four** factors, so no fold can be lopsided on a proportion |
+| `stimulus_main_effect_conditions` | 4 — `Stimulus_i{r,s}` / `Stimulus_c{r,s}`, both proportions collapsed | (a) and (c); (0)/(0b) skipped | same pooled transfer with **~4× the trials per cell**, hence less NaN padding / `mixup2` fill in the pseudopopulation. Folds are then stratified on congruency × switchType only |
+
+`cd.has_block_factor` is what decides: it returns False for a proportion the
+condition set pools over, and the block-split designs are **skipped with a
+message** rather than run on a constant.
+
+Condition sets that carry only *one* of the two factors —
+`stimulus_congruency_conditions` (`Stimulus_i`/`Stimulus_c`) and
+`stimulus_switch_type_conditions` (`Stimulus_s`/`Stimulus_r`) — **cannot** be
+used, and `cd.condition_cells` raises on them. They are separate epoch sets over
+the *same* trials, so training on one and scoring on the other would put the same
+trial in train and test: the transfer would be measured on trials the classifier
+was fit on. `stimulus_main_effect_conditions` is the crossed version of exactly
+that pooling, and it keeps the CV split honest.
 
 The class definitions are **derived from each condition's declared factor
 levels** (`cd.condition_cells`), not hand-written as substrings of the condition
@@ -1884,8 +1910,8 @@ tokens; pinned by `test_cross_decoding_condition_scheme.py`). Since each
 condition already declares its levels, `cd.condition_cells` reads those and emits
 the class groups as full condition names, which no naming change can
 misinterpret. Swapping in a different condition dict works as long as its entries
-carry `congruency`, `switchType`, `incongruentProportion` and
-`switchProportion`.
+carry `congruency` and `switchType` (plus `incongruentProportion` and
+`switchProportion` if you want the block-split designs).
 
 For the same reason `cd.filter_conditions` takes a *collection* of substrings,
 not just one: with the real naming, "the 25%-incongruent block" is the conditions
@@ -1963,6 +1989,7 @@ table (`effect_measure='cluster'`), so a real run assembles both; the
 | Want to… | Set |
 |---|---|
 | decode a different region | `ROI=acc` (keys of `src/analysis/config/rois.py`) |
+| run the pooled transfer with 4× the trials per cell (drops the within-block designs) | `CONDITIONS=stimulus_main_effect_conditions` (§17.2) |
 | use every electrode, not just baseline-significant ones | `ELECTRODES=all` |
 | move the definition window | `WINDOW_TMIN=0.2 WINDOW_TMAX=0.7` |
 | define electrodes from the power-trace runs instead | `ELECTRODE_DEFINITION=power_traces POWER_TRACES_RUN_DIR=...` (§17.3) |
@@ -1986,7 +2013,7 @@ any interaction-based selection (§17.1).
 | `EPOCHS_ROOT_FILE` | *required for real runs* | which epoched dataset to load. |
 | `DATA_SOURCE` | `real` | `real` = epoched data; `synthetic` = ground-truth dry run. |
 | `SYNTHETIC_CODE` | `shared` | synthetic only: `shared` (should cross-decode) or `orthogonal` (should not). |
-| `CONDITIONS` | `stimulus_experiment_conditions` | name of a dict in `config/experiment_conditions.py`. Must carry the full 2×2×2×2 (§17.2). |
+| `CONDITIONS` | `stimulus_experiment_conditions` | name of a dict in `config/experiment_conditions.py`. Every condition must declare `congruency` **and** `switchType`; declaring the two proportions as well is what enables the within-block designs. `stimulus_main_effect_conditions` is the pooled 2×2 alternative (§17.2). |
 
 *Which electrodes* (§17.1)
 

--- a/src/analysis/decoding/cross_decoding.py
+++ b/src/analysis/decoding/cross_decoding.py
@@ -35,7 +35,10 @@ Designs
 -------
 - **Label transfer** (Design a): `run_cross_decoding(..., train_strings=STABILITY,
   test_strings=FLEXIBILITY)`. Run it per electrode group (LWPC-only, LWPS-only,
-  `both`); the prediction is that only `both` transfers above chance.
+  `both`); the prediction is that only `both` transfers above chance. This is
+  the ALL-congruency vs ALL-switchType decode: the classes span every condition
+  cell, so it is already pooled over both block proportions. Only the
+  within-block designs below split by proportion.
 - **Set comparison** (Design b): the same contrast decoded within each electrode
   set — an ordinary decode, just with `electrodes` restricted. Use the normal
   decoding path.
@@ -115,6 +118,14 @@ def resolve_contrast(contrast):
 CELL_FIELDS = ("congruency", "switchType",
                "incongruent_proportion", "switch_proportion")
 
+# The two factors a cross-decode transfers BETWEEN. They are the only ones a
+# condition must declare: the block proportions are needed by the within-block
+# designs, not by the transfer itself, so a condition set that pools over them
+# (`stimulus_main_effect_conditions` — Stimulus_i{r,s} / Stimulus_c{r,s}, each
+# collapsing all four proportion cells) is a legitimate — and larger-per-cell —
+# input for "ALL congruency vs ALL switch type". See `has_block_factor`.
+CROSS_DECODE_FIELDS = ("congruency", "switchType")
+
 # The config spells the proportions in camelCase; the long-table / stats side of
 # the project uses snake_case. Accept either so a condition dict from either
 # convention drops in.
@@ -138,15 +149,31 @@ def _as_proportion(value):
         return None
 
 
-def condition_cells(conditions):
+def condition_cells(conditions, required=CROSS_DECODE_FIELDS):
     """`{condition_name: {field: level}}` from an `experiment_conditions`-style dict.
 
     `conditions` maps condition name -> its metadata entry (the same dict the
     decoding pipeline is driven by, e.g.
-    ``experiment_conditions.stimulus_experiment_conditions``). Conditions that do
-    not declare all four factors are dropped: a cross-decode needs every cell of
-    the 2x2x2x2, and a partially-specified condition cannot be placed in it.
+    ``experiment_conditions.stimulus_experiment_conditions``). A condition is kept
+    only if it declares every factor in `required`; undeclared factors are
+    recorded as None.
+
+    `required` defaults to the two factors the transfer runs BETWEEN
+    (`CROSS_DECODE_FIELDS`), so both of these are valid inputs:
+
+    - the full 2x2x2x2 (`stimulus_experiment_conditions`, 16 cells) — needed by
+      the within-block designs, and stratifying folds on all four factors;
+    - the pooled 2x2 (`stimulus_main_effect_conditions`, 4 cells) — congruency x
+      switchType collapsed over BOTH proportions, i.e. "all congruency vs all
+      switch type" with ~4x the trials per cell. `has_block_factor` reports
+      False for both proportions there, and the block-split designs are skipped.
+
+    Pass `required=CELL_FIELDS` to demand the full four-factor cell.
     """
+    unknown = set(required) - set(CELL_FIELDS)
+    if unknown:
+        raise ValueError(f"unknown required field(s) {sorted(unknown)}; "
+                         f"condition cells carry {CELL_FIELDS}")
     cells = {}
     for name, meta in conditions.items():
         if not isinstance(meta, dict):
@@ -157,14 +184,19 @@ def condition_cells(conditions):
             if field.endswith('proportion'):
                 value = _as_proportion(value)
             cell[field] = value
-        if any(v is None for v in cell.values()):
-            continue                       # not a full 4-factor cell
+        if any(cell[f] is None for f in required):
+            continue                       # missing a factor the decode needs
         cells[name] = cell
     if not cells:
         raise ValueError(
-            "no condition declares all of "
-            f"{CELL_FIELDS}; a cross-decode needs the full 2x2x2x2 condition set "
-            "(e.g. experiment_conditions.stimulus_experiment_conditions)")
+            f"no condition declares all of {tuple(required)}; a cross-decode "
+            "transfers BETWEEN congruency and switchType, so both must be "
+            "declared on the SAME condition (e.g. "
+            "experiment_conditions.stimulus_experiment_conditions for the full "
+            "2x2x2x2, or stimulus_main_effect_conditions for the 2x2 pooled over "
+            "the proportions). Condition sets that carry only one of the two "
+            "factors (stimulus_congruency_conditions, stimulus_switch_type_conditions) "
+            "cannot be crossed: a transfer needs both labellings of the same trial.")
     return cells
 
 
@@ -191,12 +223,31 @@ def stability_flexibility_strings(cells):
             class_strings(cells, 'switchType', 's', 'r'))
 
 
+def has_block_factor(cells, field):
+    """True when `cells` can be split on `field` — every cell declares it and at
+    least two levels are present.
+
+    False for a condition set that POOLS over a proportion (e.g.
+    `stimulus_main_effect_conditions`, which collapses both): the label-transfer
+    and temporal-generalization designs still run there, the block-split designs
+    cannot and are skipped rather than silently splitting on a constant.
+    """
+    levels = {c.get(field) for c in cells.values()}
+    return None not in levels and len(levels) > 1
+
+
 def block_condition_sets(cells, field):
     """`{level: [condition names]}` for a block factor, low level first.
 
     Feeds the within-block designs: "decode a contrast inside one block level" is
     `filter_conditions(..., block_condition_sets(cells, field)[level])`.
     """
+    if not has_block_factor(cells, field):
+        raise ValueError(
+            f"the condition set cannot be split on {field!r} (levels present: "
+            f"{sorted({str(c.get(field)) for c in cells.values()})}). It either "
+            "pools over that factor or declares only one level, so there is no "
+            "block contrast to make; check `has_block_factor` before calling.")
     levels = sorted({c[field] for c in cells.values()})
     return {level: sorted(n for n, c in cells.items() if c[field] == level)
             for level in levels}

--- a/tests/analysis/decoding/test_cross_decoding_condition_scheme.py
+++ b/tests/analysis/decoding/test_cross_decoding_condition_scheme.py
@@ -50,15 +50,70 @@ def test_camelcase_proportions_are_normalised(real_cells):
 
 
 def test_partial_conditions_are_dropped():
-    """A condition missing a factor cannot be placed in the 2x2x2x2."""
+    """A condition that declares only ONE of the two transferred factors cannot be
+    cross-decoded, so it never enters the cells."""
     conditions = dict(ec.stimulus_experiment_conditions)
     conditions['Stimulus_partial'] = {'BIDS_events': ['Stimulus'], 'congruency': 'i'}
     assert 'Stimulus_partial' not in cd.condition_cells(conditions)
 
 
-def test_a_condition_set_without_the_four_factors_raises():
-    with pytest.raises(ValueError, match='full 2x2x2x2'):
-        cd.condition_cells(ec.stimulus_congruency_conditions)
+def test_requiring_all_four_factors_still_drops_partial_cells():
+    conditions = dict(ec.stimulus_main_effect_conditions)
+    assert len(cd.condition_cells(conditions)) == 4
+    with pytest.raises(ValueError, match='no condition declares'):
+        cd.condition_cells(conditions, required=cd.CELL_FIELDS)
+
+
+def test_a_single_factor_condition_set_raises():
+    """`stimulus_congruency_conditions` / `stimulus_switch_type_conditions` carry
+    only one of the two labellings, so no condition can be crossed."""
+    for conditions in (ec.stimulus_congruency_conditions,
+                       ec.stimulus_switch_type_conditions):
+        with pytest.raises(ValueError, match='no condition declares'):
+            cd.condition_cells(conditions)
+
+
+# ---------------------------------------------------------------------------
+# the pooled 2x2: ALL congruency vs ALL switch type, collapsed over proportions
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="module")
+def pooled_cells():
+    return cd.condition_cells(ec.stimulus_main_effect_conditions)
+
+
+def test_pooled_conditions_are_the_2x2_over_both_proportions(pooled_cells):
+    assert len(pooled_cells) == 4
+    assert {c['congruency'] for c in pooled_cells.values()} == {'i', 'c'}
+    assert {c['switchType'] for c in pooled_cells.values()} == {'s', 'r'}
+    # the proportions are POOLED, not declared
+    for field in ('incongruent_proportion', 'switch_proportion'):
+        assert all(c[field] is None for c in pooled_cells.values())
+
+
+def test_pooled_conditions_still_define_both_contrasts(pooled_cells):
+    stab, flex = cd.stability_flexibility_strings(pooled_cells)
+    for name, cell in pooled_cells.items():
+        assert cd._class_of(name, stab) == (0 if cell['congruency'] == 'i' else 1)
+        assert cd._class_of(name, flex) == (0 if cell['switchType'] == 's' else 1)
+
+
+def test_has_block_factor_separates_the_two_condition_sets(real_cells, pooled_cells):
+    for field in ('incongruent_proportion', 'switch_proportion'):
+        assert cd.has_block_factor(real_cells, field)
+        assert not cd.has_block_factor(pooled_cells, field)
+        with pytest.raises(ValueError, match='cannot be split'):
+            cd.block_condition_sets(pooled_cells, field)
+
+
+def test_the_pooled_transfer_uses_every_trial(pooled_cells):
+    """The point of the pooled set: each class spans all four proportion cells, so
+    the transfer is trained and scored on ALL trials, not within a block."""
+    arrays = {'roi': {n: np.zeros((4, 2, 3)) for n in pooled_cells}}
+    stab, flex = cd.stability_flexibility_strings(pooled_cells)
+    built = cd.build_cross_decoding_arrays(arrays, 'roi', stab, flex)
+    assert set(built['conditions']) == set(pooled_cells)
+    assert built['data'].shape[0] == 4 * len(pooled_cells)
+    assert set(built['labels_train']) == set(built['labels_test']) == {0, 1}
 
 
 # ---------------------------------------------------------------------------
@@ -148,29 +203,11 @@ def _fake_roi_arrays(cells, n_channels=8, n_trials=24, n_time=16, seed=0):
     return arrays
 
 
-def test_real_branch_runs_over_real_condition_names(tmp_path, monkeypatch):
-    cells = cd.condition_cells(ec.stimulus_experiment_conditions)
-    channel_names = [f'D{i // 4}-E{i % 4}' for i in range(8)]
-    arrays = {'lpfc': _fake_roi_arrays(cells)}
-
-    labels = pd.DataFrame(dict(
-        subject=[c.split('-')[0] for c in channel_names],
-        electrode=channel_names,
-        S=[1, 1, 1, 0, 1, 1, 0, 0], F=[1, 1, 1, 1, 0, 0, 1, 0],
-        CPC=[1, 1, 1, 0, 1, 1, 0, 0], SPS=[1, 1, 1, 1, 0, 0, 1, 0],
-        CPS=[0, 0, 0, 0, 0, 0, 0, 0], SPC=[0, 0, 0, 0, 0, 0, 0, 0]))
-
-    # stub out only the two things that need the cluster's data
-    monkeypatch.setattr(xd, '_resolve_labels', lambda args, df=None: labels)
-    monkeypatch.setattr(xd, '_build_roi_arrays',
-                        lambda args, lab_root: ('lpfc', arrays, channel_names, cells))
-    monkeypatch.setattr('src.analysis.utils.general_utils.resolve_lab_root',
-                        lambda explicit=None: '/nonexistent')
-
-    args = SimpleNamespace(
+def _stub_args(tmp_path, conditions):
+    return SimpleNamespace(
         data_source='real', synthetic_code=None, LAB_root=None, subjects=[],
         task='GlobalLocal', acc_trials_only=True, epochs_root_file='epochs',
-        window_tmin=0.0, window_tmax=0.5, conditions=ec.stimulus_experiment_conditions,
+        window_tmin=0.0, window_tmax=0.5, conditions=conditions,
         electrodes='sig', rois_dict={'lpfc': []}, alpha=0.05, roi='lpfc',
         electrode_definition='power_traces', power_traces_runs='run',
         power_traces_correction='fdr_bh', power_traces_roi=None,
@@ -178,7 +215,32 @@ def test_real_branch_runs_over_real_condition_names(tmp_path, monkeypatch):
         window_size=8, step_size=8, n_splits=3, n_repeats=2,
         explained_variance=0.8, frac_train=None, n_perm=10, min_group_size=2,
         seed=0, save_dir=str(tmp_path))
-    results = xd.main(args)
+
+
+def _stub_data_loading(monkeypatch, cells, labels, channel_names):
+    """Stub out only the two things that need the cluster's data."""
+    arrays = {'lpfc': _fake_roi_arrays(cells)}
+    monkeypatch.setattr(xd, '_resolve_labels', lambda args, df=None: labels)
+    monkeypatch.setattr(xd, '_build_roi_arrays',
+                        lambda args, lab_root: ('lpfc', arrays, channel_names, cells))
+    monkeypatch.setattr('src.analysis.utils.general_utils.resolve_lab_root',
+                        lambda explicit=None: '/nonexistent')
+
+
+CHANNEL_NAMES = [f'D{i // 4}-E{i % 4}' for i in range(8)]
+LABELS = pd.DataFrame(dict(
+    subject=[c.split('-')[0] for c in CHANNEL_NAMES],
+    electrode=CHANNEL_NAMES,
+    S=[1, 1, 1, 0, 1, 1, 0, 0], F=[1, 1, 1, 1, 0, 0, 1, 0],
+    CPC=[1, 1, 1, 0, 1, 1, 0, 0], SPS=[1, 1, 1, 1, 0, 0, 1, 0],
+    CPS=[0, 0, 0, 0, 0, 0, 0, 0], SPC=[0, 0, 0, 0, 0, 0, 0, 0]))
+
+
+def test_real_branch_runs_over_real_condition_names(tmp_path, monkeypatch):
+    cells = cd.condition_cells(ec.stimulus_experiment_conditions)
+    _stub_data_loading(monkeypatch, cells, LABELS, CHANNEL_NAMES)
+
+    results = xd.main(_stub_args(tmp_path, ec.stimulus_experiment_conditions))
 
     # both contrasts decoded within both levels of their own block factor
     wb = results['within_block']
@@ -196,6 +258,33 @@ def test_real_branch_runs_over_real_condition_names(tmp_path, monkeypatch):
     for gflag, res in results['within_block_by_group'].items():
         diag = cd.circular_decode_for_group(gflag)
         assert not any(f'{diag[0]} by {diag[1]}' in cell for cell in res['cells'])
+
+    assert (tmp_path / 'cross_decoding.json').exists()
+    assert (tmp_path / 'summary.txt').exists()
+
+    # the transfer is POOLED over the proportions even here: its classes span all
+    # 16 cells, so the 16-cell set does not restrict it to within a block
+    assert len(results['label_transfer']['all']['stab_to_flex']['conditions']) == 16
+
+
+def test_pooled_branch_transfers_over_all_trials(tmp_path, monkeypatch):
+    """`stimulus_main_effect_conditions`: ALL congruency vs ALL switch type, with
+    both proportions collapsed. The transfer runs; the block designs are skipped
+    rather than split on a factor the conditions pool over."""
+    cells = cd.condition_cells(ec.stimulus_main_effect_conditions)
+    _stub_data_loading(monkeypatch, cells, LABELS, CHANNEL_NAMES)
+
+    results = xd.main(_stub_args(tmp_path, ec.stimulus_main_effect_conditions))
+
+    assert results['within_block'] == {}
+    assert results.get('within_block_by_group') is None
+
+    lt = results['label_transfer']
+    assert set(lt) >= {'both', 'all'}
+    for group, res in lt.items():
+        assert set(res) == {'stab_to_flex', 'flex_to_stab'}
+        for direction, r in res.items():
+            assert set(r['conditions']) == set(ec.stimulus_main_effect_conditions)
 
     assert (tmp_path / 'cross_decoding.json').exists()
     assert (tmp_path / 'summary.txt').exists()


### PR DESCRIPTION
The label-transfer design was already the all-congruency vs all-switchType decode -- its classes span every cell of the 2x2x2x2, so it never ran inside a block; only the within-block designs (0)/(0b) split by proportion. But the 16-cell set was the only accepted input, which meant that pooled transfer was always estimated on cells holding a quarter of the trials each, with the corresponding NaN padding and mixup fill in the pseudopopulation.

condition_cells now requires only the two factors the transfer runs BETWEEN (congruency, switchType) and records undeclared proportions as None, so stimulus_main_effect_conditions -- the same pooling, but crossed, with ~4x the trials per cell -- is a valid CONDITIONS value. has_block_factor reports which proportions a condition set can be split on; the DCC job skips the block-split designs with a message instead of splitting on a constant, and block_condition_sets raises rather than returning a single None-keyed level.

Single-factor sets (stimulus_congruency_conditions, stimulus_switch_type_conditions) still raise, now with a message saying why: they are separate epoch sets over the same trials, so training on one and scoring on the other would put the same trial in train and test.


Claude-Session: https://claude.ai/code/session_013HbL4n4u7vxf7oUowZthit