### PR TITLE
Reject condition sets where congruency and switchType are confounded

### DIFF
--- a/dcc_scripts/decoding/run_stability_flexibility_cross_decoding_dcc.py
+++ b/dcc_scripts/decoding/run_stability_flexibility_cross_decoding_dcc.py
@@ -87,9 +87,18 @@ WINDOW_TMAX = float(os.environ.get('WINDOW_TMAX', '0.5'))
 # every 'i' cell vs every 'c' cell. The 16-cell set does not restrict the
 # transfer to within a block — only designs (0)/(0b) split by block.
 #
-# Condition sets carrying just one factor (stimulus_congruency_conditions,
-# stimulus_switch_type_conditions) cannot be used: the two labellings would come
-# from separate epoch sets over the same trials, so train and test would overlap.
+# `response_experiment_conditions` is the response-locked 16-cell equivalent and
+# works the same way (pair it with a response-locked EPOCHS_ROOT_FILE).
+#
+# What CANNOT be used, and why:
+#   - sets carrying just one factor (stimulus_congruency_conditions,
+#     stimulus_switch_type_conditions): the two labellings would come from
+#     separate epoch sets over the same trials, so train and test would overlap.
+#   - sets where the two factors are CONFOUNDED rather than crossed
+#     (stimulus_iS_cR_err_conditions and its iR_cS / response_* siblings): they
+#     declare both factors, but only on cells like iS and cR, where congruency
+#     and switchType split the trials identically. main() rejects these — see
+#     `cd.factors_are_crossed`.
 CONDITIONS = getattr(experiment_conditions,
                      os.environ.get('CONDITIONS', 'stimulus_experiment_conditions'))
 

--- a/dcc_scripts/decoding/stability_flexibility_cross_decoding_dcc.py
+++ b/dcc_scripts/decoding/stability_flexibility_cross_decoding_dcc.py
@@ -630,6 +630,21 @@ def main(args):
 
     # Contrasts and block sets, read off each condition's declared factor levels
     # rather than parsed out of its name (see `cd.condition_cells`).
+    # A transfer is only identifiable if the two factors CROSS. Declaring both is
+    # not enough: a set like `stimulus_iS_cR_err_conditions` holds only the iS and
+    # cR cells, where congruency and switchType split the trials identically, so
+    # every "cross" decode below would silently re-report the within-contrast
+    # decode as perfect transfer. Fail here rather than emit that number.
+    if not cd.factors_are_crossed(cells):
+        raise ValueError(
+            f"congruency and switchType do not CROSS in this condition set "
+            f"(cells: {sorted(cells)}), so a cross-decode is not identifiable — "
+            "training on one contrast and scoring the other would measure the "
+            "contrast that was trained on. Use a set in which all four "
+            "congruency x switchType combinations are present: "
+            "stimulus_experiment_conditions (full 2x2x2x2) or "
+            "stimulus_main_effect_conditions (pooled over both proportions).")
+
     stab_strings, flex_strings = cd.stability_flexibility_strings(cells)
     # A condition set that POOLS over a proportion (e.g.
     # `stimulus_main_effect_conditions`, the 2x2 for the all-vs-all transfer) has

--- a/docs/analysis_guide.md
+++ b/docs/analysis_guide.md
@@ -1870,14 +1870,32 @@ it is the ALL-congruency vs ALL-switchType decode over all trials. Using the
 (0)/(0b) split by block, and comparing their two block levels' accuracies is what
 makes them the decoding analogue of LWPC / LWPS.
 
-A condition must declare `congruency` **and** `switchType` on the same cell —
-that is the only hard requirement, because a transfer needs both labellings of
-the *same trial*. Two sets are useful (`CONDITIONS=<name>`):
+A condition set must satisfy two things, because a transfer needs both labellings
+of the *same trial* and needs them to be separable:
+
+1. every condition declares `congruency` **and** `switchType`;
+2. the two factors **cross** — all four combinations present
+   (`cd.factors_are_crossed`).
+
+Condition (2) is not implied by (1), and this is the trap:
+`stimulus_iS_cR_err_conditions` (and its `iR_cS` / `response_*` siblings) declare
+both factors but only on the cells `iS` and `cR`, where congruency and switchType
+split the trials **identically**. Training on one and scoring the other then
+measures the contrast that was trained on, and reports the within-contrast
+accuracy as perfect transfer — a high number, not an error. `main` refuses such a
+set up front, and `build_cross_decoding_arrays` refuses the same confound when it
+arises from *filtering* instead of from the config.
+
+Two sets are useful (`CONDITIONS=<name>`):
 
 | `CONDITIONS` | Cells | Designs that run | Why pick it |
 |---|---|---|---|
 | `stimulus_experiment_conditions` (default) | 16 — the full 2×2×2×2 | all of (0), (0b), (a), (c) | the only set that supports the within-block designs; also stratifies the CV folds on **all four** factors, so no fold can be lopsided on a proportion |
 | `stimulus_main_effect_conditions` | 4 — `Stimulus_i{r,s}` / `Stimulus_c{r,s}`, both proportions collapsed | (a) and (c); (0)/(0b) skipped | same pooled transfer with **~4× the trials per cell**, hence less NaN padding / `mixup2` fill in the pseudopopulation. Folds are then stratified on congruency × switchType only |
+
+`response_experiment_conditions` is the response-locked 16-cell equivalent of the
+default and works identically (pair it with a response-locked `EPOCHS_ROOT_FILE`).
+No other dict in `experiment_conditions.py` passes both requirements.
 
 `cd.has_block_factor` is what decides: it returns False for a proportion the
 condition set pools over, and the block-split designs are **skipped with a

--- a/src/analysis/decoding/cross_decoding.py
+++ b/src/analysis/decoding/cross_decoding.py
@@ -223,6 +223,24 @@ def stability_flexibility_strings(cells):
             class_strings(cells, 'switchType', 's', 'r'))
 
 
+def factors_are_crossed(cells):
+    """True when congruency and switchType CROSS in `cells` — every combination of
+    their levels is present, so the two labellings are separable.
+
+    This is what makes a transfer identifiable, and it is not implied by both
+    factors being declared. `stimulus_iS_cR_err_conditions` declares both but
+    only as the cells iS and cR, so congruency and switchType split those trials
+    IDENTICALLY: a classifier trained on congruency and scored against switchType
+    is scored on the contrast it was trained on, and reports the within-contrast
+    accuracy as if it were perfect transfer. Nothing downstream can detect that —
+    it is a high number, not an error — so callers running a genuine cross-decode
+    must check here.
+    """
+    combos = {(c['congruency'], c['switchType']) for c in cells.values()}
+    levels = [{c[f] for c in cells.values()} for f in CROSS_DECODE_FIELDS]
+    return all(len(l) > 1 for l in levels) and len(combos) == len(levels[0]) * len(levels[1])
+
+
 def has_block_factor(cells, field):
     """True when `cells` can be split on `field` — every cell declares it and at
     least two levels are present.
@@ -341,6 +359,17 @@ def _normalize_groups(strings_to_find):
     return [list(g) for g in strings_to_find]
 
 
+def _same_partition(a, b):
+    """True when two labellings of the same trials split them the SAME way —
+    identical, or a pure renaming of the classes (e.g. 0/1 flipped).
+
+    Two labellings induce one partition exactly when the observed (a, b) pairs
+    number no more than the classes of either side: a genuinely crossed 2x2 shows
+    all four pairs, a confounded one only two.
+    """
+    return len({(x, y) for x, y in zip(a, b)}) <= max(len(set(a)), len(set(b)))
+
+
 def build_cross_decoding_arrays(roi_labeled_arrays, roi, train_strings,
                                 test_strings, obs_axs=0):
     """Turn one ROI's LabeledArray into the arrays `cv_cm_jim_window_shuffle` needs.
@@ -410,6 +439,23 @@ def build_cross_decoding_arrays(roi_labeled_arrays, roi, train_strings,
         if len(set(lab)) < 2:
             raise ValueError(f"the {name} contrast labelled every surviving "
                              f"condition the same class; nothing to decode")
+
+    # A CROSS-decode over two factors that are CONFOUNDED in the surviving
+    # conditions is not a transfer at all: the two labellings split the trials
+    # identically, so scoring against `labels_test` scores the contrast that was
+    # trained on and the "transfer" accuracy is just the within-contrast decode.
+    # Nothing downstream can detect this -- it does not error, it returns a high
+    # number that reads as perfect transfer. Requesting the same contrast for
+    # train and test is the legitimate case (that IS the within-block design), so
+    # only a genuine cross-decode is rejected.
+    if train_groups != test_groups and _same_partition(labels_train, labels_test):
+        raise ValueError(
+            f"the two contrasts are CONFOUNDED across the surviving conditions "
+            f"{kept}: they split the trials the same way, so training on one and "
+            f"scoring the other measures the trained contrast, not a transfer. A "
+            f"cross-decode needs conditions in which the two factors CROSS (all "
+            f"four congruency x switchType combinations present), e.g. "
+            f"stimulus_experiment_conditions or stimulus_main_effect_conditions.")
 
     return dict(
         data=np.concatenate(chunks, axis=obs_axs),

--- a/tests/analysis/decoding/test_cross_decoding_condition_scheme.py
+++ b/tests/analysis/decoding/test_cross_decoding_condition_scheme.py
@@ -105,6 +105,54 @@ def test_has_block_factor_separates_the_two_condition_sets(real_cells, pooled_ce
             cd.block_condition_sets(pooled_cells, field)
 
 
+@pytest.mark.parametrize('name', ['stimulus_iS_cR_err_conditions',
+                                  'stimulus_iR_cS_err_conditions',
+                                  'response_iS_cR_err_conditions',
+                                  'response_iR_cS_err_conditions'])
+def test_confounded_condition_sets_are_not_crossed(name):
+    """These declare BOTH factors, but only on cells like iS and cR — congruency
+    and switchType then split the trials IDENTICALLY (for iR/cS the two labellings
+    come out complementary, which is the same partition under a renaming), so a
+    transfer would silently report the within-contrast decode as perfect."""
+    cells = cd.condition_cells(getattr(ec, name))
+    stab, flex = cd.stability_flexibility_strings(cells)
+    assert cd._same_partition([cd._class_of(n, stab) for n in cells],
+                              [cd._class_of(n, flex) for n in cells])
+    assert not cd.factors_are_crossed(cells)
+
+
+def test_the_usable_condition_sets_are_crossed(real_cells, pooled_cells):
+    assert cd.factors_are_crossed(real_cells)
+    assert cd.factors_are_crossed(pooled_cells)
+
+
+def test_main_refuses_a_confounded_condition_set(tmp_path, monkeypatch):
+    cells = cd.condition_cells(ec.stimulus_iS_cR_err_conditions)
+    _stub_data_loading(monkeypatch, cells, LABELS, CHANNEL_NAMES)
+    with pytest.raises(ValueError, match='do not CROSS'):
+        xd.main(_stub_args(tmp_path, ec.stimulus_iS_cR_err_conditions))
+
+
+def test_a_filter_that_leaves_a_confounded_pair_is_caught(pooled_cells):
+    """The same confound can arise from FILTERING rather than from the config —
+    here the contrasts differ as strings, so the label-vector guard is what
+    catches it."""
+    arrays = {'roi': {n: np.zeros((4, 2, 3)) for n in pooled_cells}}
+    stab, flex = cd.stability_flexibility_strings(pooled_cells)
+    kept = cd.filter_conditions(arrays, 'roi', ['Stimulus_is', 'Stimulus_cr'])
+    with pytest.raises(ValueError, match='CONFOUNDED'):
+        cd.build_cross_decoding_arrays(kept, 'roi', stab, flex)
+
+
+def test_the_same_contrast_twice_is_still_allowed(pooled_cells):
+    """Train == test is the within-block design, not a confound — it must not
+    trip the crossing guard."""
+    arrays = {'roi': {n: np.zeros((4, 2, 3)) for n in pooled_cells}}
+    stab, _ = cd.stability_flexibility_strings(pooled_cells)
+    built = cd.build_cross_decoding_arrays(arrays, 'roi', stab, stab)
+    assert np.array_equal(built['labels_train'], built['labels_test'])
+
+
 def test_the_pooled_transfer_uses_every_trial(pooled_cells):
     """The point of the pooled set: each class spans all four proportion cells, so
     the transfer is trained and scored on ALL trials, not within a block."""


### PR DESCRIPTION
Relaxing condition_cells to two required factors let through sets that declare both but do not CROSS them: stimulus_iS_cR_err_conditions and its iR_cS / response_* siblings hold only the cells iS and cR, where congruency and switchType split the trials identically (for iR/cS, complementary — the same partition renamed). Training on one and scoring the other then measures the contrast that was trained on and reports the within-contrast accuracy as perfect transfer. Nothing downstream can catch that: it is a high number, not an error.

Two guards, because the confound arrives two ways. factors_are_crossed checks the condition cells and main() refuses up front — needed because the derived class strings come out literally equal there, so no string-level check can tell the case from an intentional within-decode. build_cross_decoding_arrays additionally compares the two label vectors' partitions, which catches the same confound when FILTERING leaves a confounded pair of an otherwise-crossed set; requesting the same contrast for train and test stays allowed, since that is the within-block design.


Claude-Session: https://claude.ai/code/session_013HbL4n4u7vxf7oUowZthit